### PR TITLE
Feature/getp-137: Pagination 리팩토링 및 PeopleList 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import SignUpPage from "@/pages/auth/SignUpPage";
 import HomePage from "@/pages/home/HomePage";
 
 import "./globals.css";
+import PeopleListPage from "./pages/people/PeopleListPage";
 import { persistor, store } from "@/store/store";
 import { PersistGate } from "redux-persist/lib/integration/react";
 
@@ -28,6 +29,7 @@ export default function App() {
                                     <Route path="auth/signin" element={<SignInPage />}></Route>
                                     <Route path="auth/signup" element={<SignUpPage />}></Route>
                                     <Route path="auth/findpw" element={<FindPasswordPage />}></Route>
+                                    <Route path="peopleList" element={<PeopleListPage />}></Route>
                                 </Route>
                             </Routes>
                         </AnimatePresence>

--- a/src/common/navigation/Pagination.story.ts
+++ b/src/common/navigation/Pagination.story.ts
@@ -11,8 +11,9 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
     args: {
-        currentPage: 3,
-        pageBegin: 1,
-        pageLength: 10,
+        totalItems: 125,
+        itemCountPerPage: 5,
+        pageCount: 10,
+        currentPage: 1,
     },
 };

--- a/src/common/navigation/Pagination.story.ts
+++ b/src/common/navigation/Pagination.story.ts
@@ -15,5 +15,6 @@ export const Default: Story = {
         itemCountPerPage: 5,
         pageCount: 10,
         currentPage: 1,
+        basePath: "/example",
     },
 };

--- a/src/common/navigation/Pagination.tsx
+++ b/src/common/navigation/Pagination.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import usePagination from "@/hooks/usePagination";
 
 import { PageButton, PaginationWrapper } from "./Pagination.style";
 
@@ -8,26 +7,28 @@ export interface IPagination {
     itemCountPerPage: number;
     pageCount: number;
     currentPage: number;
+    basePath: string;
 }
 
-export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage, pageCount, currentPage }) => {
-    const totalPages = Math.ceil(totalItems / itemCountPerPage);
-    // const [page, setPage] = useState<number>(currentPage);
-    const [pageBegin, setPageBegin] = useState<number>(1);
-    const noPrev = pageBegin === 1;
-    const noNext = pageBegin + pageCount - 1 >= totalPages;
-    const navigate = useNavigate();
-
-    useEffect(() => {
-        if (currentPage === pageBegin + pageCount) setPageBegin((prev) => prev + pageCount);
-        if (currentPage < pageBegin) setPageBegin((prev) => prev - pageCount);
-        // console.log(`pageBegin = ${pageBegin}`);
-    }, [currentPage, pageCount, pageBegin]);
+export const Pagination: React.FC<IPagination> = ({
+    totalItems,
+    itemCountPerPage,
+    pageCount,
+    currentPage,
+    basePath,
+}) => {
+    const { pageBegin, noPrev, noNext, totalPages, gotoPrev, gotoNext, gotoPage } = usePagination({
+        totalItems,
+        itemCountPerPage,
+        pageCount,
+        currentPage,
+        basePath,
+    });
 
     return (
         <PaginationWrapper>
             {!noPrev && (
-                <PageButton onClick={() => navigate(`/peopleList?page=${pageBegin - 1}`)} active={false}>
+                <PageButton onClick={gotoPrev} active={false}>
                     {"<"}
                 </PageButton>
             )}
@@ -37,7 +38,7 @@ export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage
                         {value <= totalPages && (
                             <PageButton
                                 key={pageBegin + index}
-                                onClick={() => navigate(`/peopleList?page=${value}`)}
+                                onClick={() => gotoPage(value)}
                                 active={currentPage === pageBegin + index}
                             >
                                 {pageBegin + index}
@@ -47,10 +48,12 @@ export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage
                 );
             })}
             {!noNext && (
-                <PageButton onClick={() => navigate(`/peopleList?page=${pageBegin + pageCount}`)} active={false}>
+                <PageButton onClick={gotoNext} active={false}>
                     {">"}
                 </PageButton>
             )}
         </PaginationWrapper>
     );
 };
+
+export default Pagination;

--- a/src/common/navigation/Pagination.tsx
+++ b/src/common/navigation/Pagination.tsx
@@ -1,29 +1,68 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { PageButton, PaginationWrapper } from "./Pagination.style";
 
 export interface IPagination {
+    totalItems: number;
+    itemCountPerPage: number;
+    pageCount: number;
     currentPage: number;
-    pageBegin: number;
-    pageLength: number;
 }
 
-export const Pagination: React.FC<IPagination> = ({ currentPage, pageBegin, pageLength }) => {
+export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage, pageCount, currentPage }) => {
+    const totalPages = Math.ceil(totalItems / itemCountPerPage);
     const [page, setPage] = useState<number>(currentPage);
+    const [pageBegin, setPageBegin] = useState<number>(1);
+    const [pageState, setPageState] = useState({
+        noPrev: pageBegin === 1,
+        noNext: pageBegin + pageCount - 1 >= totalPages,
+    });
 
-    const handlePageBtnClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
-        setPage(parseInt(e.currentTarget.innerHTML));
+    useEffect(() => {
+        const newPageState = {
+            noPrev: pageBegin === 1,
+            noNext: pageBegin + pageCount - 1 >= totalPages,
+        };
+        setPageState(() => newPageState);
+    }, [pageBegin, pageCount, totalPages]);
+
+    useEffect(() => {
+        const newPageBegin = Math.floor((page - 1) / pageCount) * pageCount + 1;
+        setPageBegin(() => newPageBegin);
+        console.log(`currentpage = ${page}`);
+    }, [page, pageCount]);
+
+    const handlePageBtnClick = useCallback((pageNum: number) => {
+        setPage(pageNum);
     }, []);
 
     return (
         <PaginationWrapper>
-            {Array.from({ length: pageLength }, (_, i) => pageBegin + i).map((value, index) => {
+            {!pageState.noPrev && (
+                <PageButton onClick={() => handlePageBtnClick(pageBegin - 1)} active={false}>
+                    {"<"}
+                </PageButton>
+            )}
+            {Array.from({ length: pageCount }, (_, i) => pageBegin + i).map((value, index) => {
                 return (
-                    <PageButton key={index} onClick={handlePageBtnClick} active={page === value}>
-                        {value}
-                    </PageButton>
+                    <>
+                        {value <= totalPages && (
+                            <PageButton
+                                key={pageBegin + index}
+                                onClick={() => handlePageBtnClick(value)}
+                                active={page === pageBegin + index}
+                            >
+                                {pageBegin + index}
+                            </PageButton>
+                        )}
+                    </>
                 );
             })}
+            {!pageState.noNext && (
+                <PageButton onClick={() => handlePageBtnClick(pageBegin + pageCount)} active={false}>
+                    {">"}
+                </PageButton>
+            )}
         </PaginationWrapper>
     );
 };

--- a/src/common/navigation/Pagination.tsx
+++ b/src/common/navigation/Pagination.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { PageButton, PaginationWrapper } from "./Pagination.style";
 
@@ -11,35 +12,22 @@ export interface IPagination {
 
 export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage, pageCount, currentPage }) => {
     const totalPages = Math.ceil(totalItems / itemCountPerPage);
-    const [page, setPage] = useState<number>(currentPage);
+    // const [page, setPage] = useState<number>(currentPage);
     const [pageBegin, setPageBegin] = useState<number>(1);
-    const [pageState, setPageState] = useState({
-        noPrev: pageBegin === 1,
-        noNext: pageBegin + pageCount - 1 >= totalPages,
-    });
+    const noPrev = pageBegin === 1;
+    const noNext = pageBegin + pageCount - 1 >= totalPages;
+    const navigate = useNavigate();
 
     useEffect(() => {
-        const newPageState = {
-            noPrev: pageBegin === 1,
-            noNext: pageBegin + pageCount - 1 >= totalPages,
-        };
-        setPageState(() => newPageState);
-    }, [pageBegin, pageCount, totalPages]);
-
-    useEffect(() => {
-        const newPageBegin = Math.floor((page - 1) / pageCount) * pageCount + 1;
-        setPageBegin(() => newPageBegin);
-        console.log(`currentpage = ${page}`);
-    }, [page, pageCount]);
-
-    const handlePageBtnClick = useCallback((pageNum: number) => {
-        setPage(pageNum);
-    }, []);
+        if (currentPage === pageBegin + pageCount) setPageBegin((prev) => prev + pageCount);
+        if (currentPage < pageBegin) setPageBegin((prev) => prev - pageCount);
+        // console.log(`pageBegin = ${pageBegin}`);
+    }, [currentPage, pageCount, pageBegin]);
 
     return (
         <PaginationWrapper>
-            {!pageState.noPrev && (
-                <PageButton onClick={() => handlePageBtnClick(pageBegin - 1)} active={false}>
+            {!noPrev && (
+                <PageButton onClick={() => navigate(`/peopleList?page=${pageBegin - 1}`)} active={false}>
                     {"<"}
                 </PageButton>
             )}
@@ -49,8 +37,8 @@ export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage
                         {value <= totalPages && (
                             <PageButton
                                 key={pageBegin + index}
-                                onClick={() => handlePageBtnClick(value)}
-                                active={page === pageBegin + index}
+                                onClick={() => navigate(`/peopleList?page=${value}`)}
+                                active={currentPage === pageBegin + index}
                             >
                                 {pageBegin + index}
                             </PageButton>
@@ -58,8 +46,8 @@ export const Pagination: React.FC<IPagination> = ({ totalItems, itemCountPerPage
                     </>
                 );
             })}
-            {!pageState.noNext && (
-                <PageButton onClick={() => handlePageBtnClick(pageBegin + pageCount)} active={false}>
+            {!noNext && (
+                <PageButton onClick={() => navigate(`/peopleList?page=${pageBegin + pageCount}`)} active={false}>
                     {">"}
                 </PageButton>
             )}

--- a/src/components/people/PeopleCard.tsx
+++ b/src/components/people/PeopleCard.tsx
@@ -9,8 +9,8 @@ import {
 } from "./PeopleCard.style";
 
 export interface IPeopleCard {
-    width: string;
-    height: string;
+    width?: string;
+    height?: string;
     profileImageUri: string;
     nickname: string;
     activityArea: string;
@@ -20,8 +20,8 @@ export interface IPeopleCard {
 }
 
 export const PeopleCard: React.FC<IPeopleCard> = ({
-    width,
-    height,
+    width = "522px",
+    height = "110px",
     profileImageUri,
     nickname,
     activityArea,

--- a/src/components/people/PeopleSearch.story.ts
+++ b/src/components/people/PeopleSearch.story.ts
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 export const PeopleSearchBar: Story = {
     args: {
-        width: "1068px",
+        width: "1080px",
         height: "110px",
     },
 };

--- a/src/constants/peopleInfo.ts
+++ b/src/constants/peopleInfo.ts
@@ -1,0 +1,17 @@
+export interface IPeopleInfo {
+    profileImageUri: string;
+    nickname: string;
+    activityArea: string;
+    hashtags: string[];
+    completeProjectsCount: number;
+    comment: string;
+}
+
+export const PeopleInfos: IPeopleInfo[] = new Array(100).fill(null).map(() => ({
+    profileImageUri: "/src/assets/people/img_profile_default.png",
+    nickname: "유진",
+    comment: "안녕하세요. 경북대 컴퓨터학부 김유진입니다. 우하하우하하",
+    activityArea: "대구광역시 동구",
+    hashtags: ["#돈까스", "#히히", "#점심"],
+    completeProjectsCount: 5,
+}));

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+interface PaginationOptions {
+    totalItems: number;
+    itemCountPerPage: number;
+    pageCount: number;
+    currentPage: number;
+    basePath: string;
+}
+
+interface PaginationResult {
+    pageBegin: number;
+    noPrev: boolean;
+    noNext: boolean;
+    totalPages: number;
+    gotoPrev: () => void;
+    gotoNext: () => void;
+    gotoPage: (pageNumber: number) => void;
+}
+
+const usePagination = ({
+    totalItems,
+    itemCountPerPage,
+    pageCount,
+    currentPage,
+    basePath,
+}: PaginationOptions): PaginationResult => {
+    const totalPages = Math.ceil(totalItems / itemCountPerPage);
+    const [pageBegin, setPageBegin] = useState(1);
+    const noPrev = pageBegin === 1;
+    const noNext = pageBegin + pageCount - 1 >= totalPages;
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        if (currentPage === pageBegin + pageCount) setPageBegin((prev) => prev + pageCount);
+        if (currentPage < pageBegin) setPageBegin((prev) => prev - pageCount);
+    }, [currentPage, pageCount, pageBegin]);
+
+    const gotoPrev = () => {
+        if (!noPrev) {
+            navigate(`${basePath}?page=${pageBegin - 1}`);
+        }
+    };
+
+    const gotoNext = () => {
+        if (!noNext) {
+            navigate(`${basePath}?page=${pageBegin + pageCount}`);
+        }
+    };
+
+    const gotoPage = (pageNumber: number) => {
+        navigate(`${basePath}?page=${pageNumber}`);
+    };
+
+    return { pageBegin, noPrev, noNext, totalPages, gotoPrev, gotoNext, gotoPage };
+};
+
+export default usePagination;

--- a/src/pages/people/PeopleListPage.style.tsx
+++ b/src/pages/people/PeopleListPage.style.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+export const PeopleListWrapper = styled.section`
+    width: min(100%, 1080px);
+    margin: 40px auto;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;

--- a/src/pages/people/PeopleListPage.style.tsx
+++ b/src/pages/people/PeopleListPage.style.tsx
@@ -9,3 +9,15 @@ export const PeopleListWrapper = styled.section`
     justify-content: center;
     align-items: center;
 `;
+
+export const PeopleListContainer = styled.section`
+    width: auto;
+    margin: 40px auto;
+
+    gap: 24px 0px;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+`;

--- a/src/pages/people/PeopleListPage.tsx
+++ b/src/pages/people/PeopleListPage.tsx
@@ -11,7 +11,7 @@ import { IPeopleInfo, PeopleInfos } from "@/constants/peopleInfo";
 import { PeopleListContainer, PeopleListWrapper } from "./PeopleListPage.style";
 
 export default function PeopleListPage() {
-    const [totalItems, setTotalItems] = useState(100);
+    const [totalItems] = useState(100);
     const [people, setPeople] = useState<IPeopleInfo[] | null>(null);
     const [searchParams] = useSearchParams();
     const itemCountPerPage = 6;

--- a/src/pages/people/PeopleListPage.tsx
+++ b/src/pages/people/PeopleListPage.tsx
@@ -1,14 +1,56 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+
 import { Pagination } from "@/common/navigation/Pagination";
 
+import { PeopleCard } from "@/components/people/PeopleCard";
 import { PeopleSearch } from "@/components/people/PeopleSearch";
 
-import { PeopleListWrapper } from "./PeopleListPage.style";
+import { IPeopleInfo, PeopleInfos } from "@/constants/peopleInfo";
+
+import { PeopleListContainer, PeopleListWrapper } from "./PeopleListPage.style";
 
 export default function PeopleListPage() {
+    const [totalItems, setTotalItems] = useState(100);
+    const [people, setPeople] = useState<IPeopleInfo[] | null>(null);
+    const [searchParams] = useSearchParams();
+    const itemCountPerPage = 6;
+    const pageCount = 10;
+    const page = searchParams.get("page");
+
+    useEffect(() => {
+        // window.scrollTo(0, 0); // 페이지 이동 시 스크롤 위치 맨 위로 초기화
+        /* api 호출 및 데이터(totalItems, people) 저장 */
+        setPeople(PeopleInfos.slice(0, itemCountPerPage));
+    }, [page]);
+
     return (
         <PeopleListWrapper>
             <PeopleSearch width="100%" height="auto" />
-            <Pagination totalItems={200} itemCountPerPage={6} pageCount={10} currentPage={21} />
+            <PeopleListContainer>
+                {people && (
+                    <>
+                        {people.map((person) => (
+                            <PeopleCard
+                                width="auto"
+                                height="auto"
+                                profileImageUri={person.profileImageUri}
+                                nickname={person.nickname}
+                                comment={person.comment}
+                                activityArea={person.activityArea}
+                                hashtags={person.hashtags}
+                                completeProjectsCount={person.completeProjectsCount}
+                            />
+                        ))}
+                    </>
+                )}
+            </PeopleListContainer>
+            <Pagination
+                totalItems={totalItems}
+                itemCountPerPage={itemCountPerPage}
+                pageCount={pageCount}
+                currentPage={page && parseInt(page) > 0 ? parseInt(page) : 1}
+            />
         </PeopleListWrapper>
     );
 }

--- a/src/pages/people/PeopleListPage.tsx
+++ b/src/pages/people/PeopleListPage.tsx
@@ -50,6 +50,7 @@ export default function PeopleListPage() {
                 itemCountPerPage={itemCountPerPage}
                 pageCount={pageCount}
                 currentPage={page && parseInt(page) > 0 ? parseInt(page) : 1}
+                basePath="/peopleList"
             />
         </PeopleListWrapper>
     );

--- a/src/pages/people/PeopleListPage.tsx
+++ b/src/pages/people/PeopleListPage.tsx
@@ -1,0 +1,14 @@
+import { Pagination } from "@/common/navigation/Pagination";
+
+import { PeopleSearch } from "@/components/people/PeopleSearch";
+
+import { PeopleListWrapper } from "./PeopleListPage.style";
+
+export default function PeopleListPage() {
+    return (
+        <PeopleListWrapper>
+            <PeopleSearch width="100%" height="auto" />
+            <Pagination totalItems={200} itemCountPerPage={6} pageCount={10} currentPage={21} />
+        </PeopleListWrapper>
+    );
+}


### PR DESCRIPTION
## ✨ 구현한 기능

1. **PeopleList 페이지 구현**: /peopleList 경로에 위치한 PeopleList 페이지를 구현하였습니다.

2. **페이지 버튼 및 쿼리 파라미터 구현**: 페이지 버튼을 클릭할 때마다 쿼리 파라미터 page에 해당 페이지 번호를 전달하도록 구현하였습니다. 예를 들어, ?page=1, ?page=2와 같이 페이지 번호를 쿼리 파라미터로 전달합니다.

3. **파라미터 처리**: PeopleList 페이지에서는 useSearchParams 훅을 이용하여 URL의 쿼리 파라미터를 가져옵니다. 그리고 이 중에서 page 값을 추출하여 현재 페이지를 얻어옵니다.

4. **Pagination 구현**: 얻어온 현재 페이지 값을 Pagination 컴포넌트에 전달하여 현재 페이지를 표시하도록 구현하였습니다.

![image](https://github.com/Principes-Artis-Mechanicae/get-p-frontend/assets/68093782/7d25d112-8e22-4173-9ac7-fdef5688371e)


## 📢 논의하고 싶은 내용

- api로 받아올 People 데이터의 interface를 어디에 선언하면 좋을까요?
- 이제 파일이 너무 많아져서 폴더 별로 분리해서 정리해야 할 필요가 있을 것 같습니다.

## 🎸 기타

- api 연결 후 데이터 가져와서 뿌리면 될 듯.
- 처음 Pagination을 refactoring 했을 때는 페이지를 state로 관리해서 Storybook에서도 테스팅이 가능했으나, 지금은 Navigate를 사용해서 storybook에서 작동하지 않음ㅠ.
