### PR TITLE
GETP-123 fix: 토큰 재발급 로직 수정

### DIFF
--- a/src/common/guard/RouteGuard.tsx
+++ b/src/common/guard/RouteGuard.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "react-redux";
-import { Navigate, Route } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import { toast } from "react-toastify";
 
 import { MemberType } from "@/services/auth/auth.types";
@@ -13,7 +13,7 @@ export interface ProtectedRouteProps {
 
 /**
  * role 이 로그인된 사용자 memberType 과 일치하는 경우 children 하위 컴포넌트를 렌더링 합니다
- * 로그인이 되지 않은 상요자는 로그인페이지로 리다이렉트 됩니다
+ * 로그인이 되지 않은 사용자는 로그인페이지로 리다이렉트 됩니다
  * 권한이 없는 경우 홈 페이지로 리다이렉트 됩니다
  */
 export const RouteGuard = ({ role, children }: ProtectedRouteProps) => {

--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -13,7 +13,7 @@ export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
 
 export const api = axios.create({
     baseURL: API_BASE_URL,
-    timeout: 5000,
+    // timeout: 5000,
     headers: {
         "Content-Type": "application/json",
     },
@@ -22,12 +22,11 @@ export const api = axios.create({
 api.interceptors.request.use(
     async (config) => {
         const { accessToken, refreshToken } = store.getState().auth;
+        if (accessToken === null || refreshToken === null) return config;
 
-        if (accessToken !== null && refreshToken !== null && isExpired(accessToken)) {
-            const { accessToken: newAccessToken, refreshToken: newRefreshToken } = await authService.reissueToken(
-                accessToken,
-                refreshToken,
-            );
+        if (isExpired(accessToken)) {
+            const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
+                await authService.reissueToken(accessToken);
 
             store.dispatch(
                 authAction.reissueToken({
@@ -39,8 +38,7 @@ api.interceptors.request.use(
             config.headers["Authorization"] = `Bearer ${newAccessToken}`;
             return config;
         }
-
-        config.headers["Authorization"] = `Bearer ${accessToken as string}`;
+        config.headers["Authorization"] = `Bearer ${accessToken}`;
         return config;
     },
     (error: AxiosError) => {

--- a/src/services/auth/auth.service.ts
+++ b/src/services/auth/auth.service.ts
@@ -112,12 +112,13 @@ export const authService = {
         });
     },
 
-    reissueToken: async (refreshToken: string) => {
+    reissueToken: async (accessToken: string, refreshToken: string) => {
         const response = await fetch(API_BASE_URL + "auth/reissue", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${refreshToken}`,
+                Authorization: `Bearer ${accessToken}`,
+                "Refresh-Token": `Bearer ${refreshToken}`,
             },
         });
 

--- a/src/services/auth/auth.service.ts
+++ b/src/services/auth/auth.service.ts
@@ -112,12 +112,11 @@ export const authService = {
         });
     },
 
-    reissueToken: async (accessToken: string, refreshToken: string) => {
+    reissueToken: async (refreshToken: string) => {
         const response = await fetch(API_BASE_URL + "auth/reissue", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                Authorization: `Bearer ${accessToken}`,
                 "Refresh-Token": `Bearer ${refreshToken}`,
             },
         });

--- a/src/store/thunk/auth.thunk.ts
+++ b/src/store/thunk/auth.thunk.ts
@@ -4,7 +4,7 @@ import { authService } from "@/services/auth/auth.service";
 import { memberService } from "@/services/member/member.service";
 
 import { authAction } from "../slice/auth.slice";
-import { GetState, RootDispatch } from "../store";
+import { RootDispatch } from "../store";
 
 export const signInThunkAction = (email: string, password: string, navigate: NavigateFunction) => {
     return async (dispatch: RootDispatch) => {
@@ -36,23 +36,5 @@ export const signInThunkAction = (email: string, password: string, navigate: Nav
         );
 
         navigate("/");
-    };
-};
-
-export const reissueTokenThunkAction = () => {
-    return async (dispatch: RootDispatch, getState: GetState) => {
-        const { refreshToken } = getState().auth;
-
-        const response = await authService.reissueToken(refreshToken as string);
-
-        const newAccessToken = response.accessToken;
-        const newRefreshToken = response.refreshToken;
-
-        dispatch(
-            authAction.reissueToken({
-                accessToken: newAccessToken,
-                refreshToken: newRefreshToken,
-            }),
-        );
     };
 };


### PR DESCRIPTION
## ✨ 구현한 기능

- 토큰 재발급시 accessToken, refreshToken 을 모두 header 로 넘겨주도록 수정
- axios request interceptor 재발급 로직 수정
- accessToken, refreshToken 이 null 인 경우, header 의 authorization 필드에 들어가지 않도록 수정

## 📢 논의하고 싶은 내용

-

## 🎸 기타

-
