### PR TITLE
GETP-159 feature: 피플 프로필 편집 API 연동

### DIFF
--- a/src/common/form/Input.story.tsx
+++ b/src/common/form/Input.story.tsx
@@ -1,3 +1,7 @@
+import { useInputValidation } from "@/hooks/useInputValidation";
+
+import { REGEXP_PASSWORD } from "@/constants/regex";
+
 import { Button } from "./Button";
 import { Input } from "./Input";
 import { css } from "@emotion/react";
@@ -26,6 +30,21 @@ export const Password: Story = {
         width: "300px",
         height: "45px",
         placeholder: "비밀번호를 입력해주세요",
+    },
+    render: (args) => {
+        const { value, isValid, onChange } = useInputValidation(REGEXP_PASSWORD);
+
+        return (
+            <Input
+                type={args.type}
+                onChange={onChange}
+                value={value}
+                width={args.width}
+                height={args.height}
+                placeholder={args.placeholder}
+                error={isValid ? "" : "비밀번호는 영문,숫자,특수문자로 조합된 8-20자 이어야 합니다"}
+            />
+        );
     },
 };
 

--- a/src/common/form/TextArea.tsx
+++ b/src/common/form/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { forwardRef, useCallback } from "react";
 
 import { TextAreaContainer, ITextAreaElement, TextAreaElement, TextDeleteButton } from "./TextArea.style";
 
@@ -7,31 +7,34 @@ export interface ITextArea extends ITextAreaElement {
     children?: React.ReactNode;
 }
 
-export const TextArea: React.FC<ITextArea> = ({ width, height, variant, placeholder, children }) => {
-    const textAreaRef = useRef<HTMLTextAreaElement>(null);
+export const TextArea = forwardRef<HTMLTextAreaElement, ITextArea>(
+    ({ width, height, variant, placeholder, children }, ref) => {
+        const handleDelete = useCallback(() => {
+            // ref 가 정의 되어 있고
+            // ref 객체에 current 프로퍼티가 존재하고
+            // ref.current 가 정의된 경우
+            if (ref && "current" in ref && ref.current) {
+                ref.current.value = "";
+            }
+        }, [ref]);
 
-    const handleDelete = () => {
-        if (textAreaRef.current) {
-            textAreaRef.current.value = "";
-        }
-    };
+        const TextAreaElement_ = (
+            <TextAreaElement ref={ref} variant={variant} width={width} height={height} placeholder={placeholder}>
+                {children}
+            </TextAreaElement>
+        );
 
-    const textAreaElement = (
-        <TextAreaElement ref={textAreaRef} variant={variant} width={width} height={height} placeholder={placeholder}>
-            {children}
-        </TextAreaElement>
-    );
-
-    return (
-        <>
-            {variant === "primary" ? (
-                <TextAreaContainer>
-                    {textAreaElement}
-                    <TextDeleteButton onClick={handleDelete}></TextDeleteButton>
-                </TextAreaContainer>
-            ) : (
-                textAreaElement
-            )}
-        </>
-    );
-};
+        return (
+            <>
+                {variant === "primary" ? (
+                    <TextAreaContainer>
+                        {TextAreaElement_}
+                        <TextDeleteButton onClick={handleDelete} />
+                    </TextAreaContainer>
+                ) : (
+                    TextAreaElement_
+                )}
+            </>
+        );
+    },
+);

--- a/src/common/helper/withProviders.tsx
+++ b/src/common/helper/withProviders.tsx
@@ -1,0 +1,34 @@
+import { cloneElement } from "react";
+
+/**
+ *
+ * @param providers Component 를 감쌀 Context Provider 컴포넌트 배열
+ * @param Component Context Provider 로 감쌀 Component
+ * @returns ProvidersWrappedComponent
+ *
+ * @example PageComponent 에 ProviderA, ProviderB, ProviderC 를 감싼 컴포넌트
+ * const WrappedPageComponent = withProviders(
+ *      [
+ *          <ProviderA/>
+ *          <ProviderB/>
+ *          <ProviderC/>
+ *      ],
+ *      function PageComponent() {
+ *          return <></>
+ *      }
+ * )
+ */
+export const withProviders = <Props extends object>(
+    providers: React.ReactElement[],
+    Component: React.ComponentType<Props>,
+) => {
+    return (props: Props) => {
+        const ProvidersWrappedComponent = providers.reduceRight(
+            (providers, provider) => {
+                return cloneElement(provider, {}, providers);
+            },
+            <Component {...props} />,
+        );
+        return ProvidersWrappedComponent;
+    };
+};

--- a/src/components/people/ProfileHashTag.story.tsx
+++ b/src/components/people/ProfileHashTag.story.tsx
@@ -1,4 +1,5 @@
 import { ProfileHashTag } from "./ProfileHashTag";
+import { HashTagProvider } from "@/contexts/HashTagContext";
 import type { Meta, StoryObj } from "@storybook/react";
 
 const meta = {
@@ -14,5 +15,12 @@ export const Default: Story = {
     args: {
         width: "268px",
         minHeight: "120px",
+    },
+    render: (args) => {
+        return (
+            <HashTagProvider>
+                <ProfileHashTag width={args.width} minHeight={args.minHeight} />
+            </HashTagProvider>
+        );
     },
 };

--- a/src/components/people/ProfileHashTag.tsx
+++ b/src/components/people/ProfileHashTag.tsx
@@ -1,6 +1,8 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 
 import { Text } from "@/common/typography/Text";
+
+import { useHashTag } from "@/hooks/useHashTag";
 
 import {
     ProfileHashTagWrapper,
@@ -16,14 +18,15 @@ export interface IProfileHashTag {
 
 export const ProfileHashTag: React.FC<IProfileHashTag> = ({ width, minHeight }) => {
     const inputRef = useRef<HTMLInputElement>(null);
-    const [hashTagItems, setHashTagItems] = useState<string[]>([]);
+    const { hashtag, setHashTag } = useHashTag();
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        // BUG : 한글 입력시 두번 등록되는 버그
         if (e.key === "Enter" && inputRef.current) {
             const value = inputRef.current.value.trim();
 
-            if (value && hashTagItems.length < 15) {
-                setHashTagItems([...hashTagItems, value]);
+            if (value && hashtag.length < 15) {
+                setHashTag((hashtag) => [...hashtag, value]);
                 inputRef.current.value = "";
             }
         }
@@ -34,7 +37,7 @@ export const ProfileHashTag: React.FC<IProfileHashTag> = ({ width, minHeight }) 
                 해시태그
             </Text>
             <ProfileHashTagContainer>
-                {hashTagItems.map((item, index) => (
+                {hashtag.map((item, index) => (
                     <ProfileHashTagItem key={index}>#{item}</ProfileHashTagItem>
                 ))}
             </ProfileHashTagContainer>

--- a/src/contexts/AccordionContext.tsx
+++ b/src/contexts/AccordionContext.tsx
@@ -104,7 +104,7 @@ const reducer: React.Reducer<AccordionState, AccordionAction> = (state, action) 
     }
 };
 
-export const AccordionProvider = ({ children }: { children: React.ReactNode }) => {
+export const AccordionProvider = ({ children }: { children?: React.ReactNode }) => {
     const [state, dispatch] = useReducer(reducer, accordionState);
 
     return (

--- a/src/contexts/HashTagContext.tsx
+++ b/src/contexts/HashTagContext.tsx
@@ -1,0 +1,11 @@
+import { useState, createContext } from "react";
+
+export const HashTagContext = createContext<{
+    hashtag: string[];
+    setHashTag: React.Dispatch<React.SetStateAction<string[]>>;
+} | null>(null);
+
+export const HashTagProvider = ({ children }: { children?: React.ReactNode }) => {
+    const [hashtag, setHashTag] = useState<string[]>([]);
+    return <HashTagContext.Provider value={{ hashtag, setHashTag }}>{children}</HashTagContext.Provider>;
+};

--- a/src/contexts/TechStackContext.tsx
+++ b/src/contexts/TechStackContext.tsx
@@ -61,7 +61,7 @@ const reducer: React.Reducer<TechStackState, TechStackAction> = (state, action) 
     }
 };
 
-export const TechStackProvider = ({ children }: { children: React.ReactNode }) => {
+export const TechStackProvider = ({ children }: { children?: React.ReactNode }) => {
     const [state, dispatch] = useReducer(reducer, techStackState);
 
     return <TechStackContext.Provider value={{ state, dispatch }}>{children}</TechStackContext.Provider>;

--- a/src/hooks/useHashTag.ts
+++ b/src/hooks/useHashTag.ts
@@ -1,0 +1,9 @@
+import { useContext } from "react";
+
+import { HashTagContext } from "@/contexts/HashTagContext";
+
+export const useHashTag = () => {
+    const hashtagContext = useContext(HashTagContext);
+    if (!hashtagContext) throw new Error("useHashTag 훅은 HashTagProvider 내부에서 사용되어야 합니다");
+    return hashtagContext;
+};

--- a/src/pages/people/PeopleProfileEditPage.tsx
+++ b/src/pages/people/PeopleProfileEditPage.tsx
@@ -2,12 +2,15 @@ import { Button } from "@/common/form/Button";
 import { Input } from "@/common/form/Input";
 import { Label } from "@/common/form/Label";
 import { TextArea } from "@/common/form/TextArea";
+import { withProviders } from "@/common/helper/withProviders";
 import { Text } from "@/common/typography/Text";
 import { Title } from "@/common/typography/Title";
 
 import { Profile } from "@/components/people/Profile";
 import { ProfileHashTag } from "@/components/people/ProfileHashTag";
 import { TechStackSelector } from "@/components/people/TechStackSelector";
+
+import { usePeopleProfileEdit } from "@/services/people/usePeopleProfileEdit";
 
 import { techStack } from "@/constants/techstack";
 
@@ -19,75 +22,81 @@ import {
     PeopleProfileEditPageWrapper,
 } from "./PeopleProfileEditPage.style";
 import { AccordionProvider } from "@/contexts/AccordionContext";
+import { HashTagProvider } from "@/contexts/HashTagContext";
 import { TechStackProvider } from "@/contexts/TechStackContext";
 import { css } from "@emotion/react";
 
-export default function PeopleProfileEditPage() {
-    return (
-        <PeopleProfileEditPageWrapper>
-            <PeopleProfileEditPageAside>
-                <Profile width="100%" height="280px" nickname={"닉네임"} likeCount={0} completeProjectsCount={0} />
-                <ProfileHashTag width="100%" minHeight="120px"></ProfileHashTag>
-            </PeopleProfileEditPageAside>
+const PeopleProfileEditPage = withProviders(
+    [<TechStackProvider />, <AccordionProvider />, <HashTagProvider />],
+    function PeopleProfileEditPage() {
+        const { schoolRef, majorRef, activityAreaRef, introductionRef, handleAddPortfolio, handleEditBtnClicked } =
+            usePeopleProfileEdit();
 
-            <PeopleProfileEditPageContainer>
-                <Title>
-                    <Text size="l" weight="bold" color="#476FF1">
-                        피플 프로필 편집하기
-                    </Text>
-                </Title>
+        return (
+            <PeopleProfileEditPageWrapper>
+                <PeopleProfileEditPageAside>
+                    <Profile width="100%" height="280px" nickname={"닉네임"} likeCount={0} completeProjectsCount={0} />
+                    <ProfileHashTag width="100%" minHeight="120px" />
+                </PeopleProfileEditPageAside>
 
-                <PeopleProfileEditForm>
-                    <PeopleProfileEditFormItem>
-                        <Label>학교명</Label>
-                        <Input width="100%" height="35px"></Input>
-                    </PeopleProfileEditFormItem>
+                <PeopleProfileEditPageContainer>
+                    <Title>
+                        <Text size="l" weight="bold" color="#476FF1">
+                            피플 프로필 편집하기
+                        </Text>
+                    </Title>
 
-                    <PeopleProfileEditFormItem>
-                        <Label>전공명</Label>
-                        <Input width="100%" height="35px"></Input>
-                    </PeopleProfileEditFormItem>
+                    <PeopleProfileEditForm>
+                        <PeopleProfileEditFormItem>
+                            <Label>학교명</Label>
+                            <Input ref={schoolRef} width="100%" height="35px"></Input>
+                        </PeopleProfileEditFormItem>
 
-                    <PeopleProfileEditFormItem>
-                        <Label>활동지역</Label>
-                        <Input width="100%" height="35px"></Input>
-                    </PeopleProfileEditFormItem>
+                        <PeopleProfileEditFormItem>
+                            <Label>전공명</Label>
+                            <Input ref={majorRef} width="100%" height="35px"></Input>
+                        </PeopleProfileEditFormItem>
 
-                    <PeopleProfileEditFormItem>
-                        <Label>소개</Label>
-                        <TextArea variant="primary" width="100%" height="240px"></TextArea>
-                    </PeopleProfileEditFormItem>
+                        <PeopleProfileEditFormItem>
+                            <Label>활동지역</Label>
+                            <Input ref={activityAreaRef} width="100%" height="35px"></Input>
+                        </PeopleProfileEditFormItem>
 
-                    <PeopleProfileEditFormItem>
-                        <Label>기술스택</Label>
-                        <TechStackProvider>
-                            <AccordionProvider>
-                                <TechStackSelector techStack={techStack} width="100$" height="350px" />
-                            </AccordionProvider>
-                        </TechStackProvider>
-                    </PeopleProfileEditFormItem>
+                        <PeopleProfileEditFormItem>
+                            <Label>소개</Label>
+                            <TextArea ref={introductionRef} variant="primary" width="100%" height="240px"></TextArea>
+                        </PeopleProfileEditFormItem>
 
-                    <PeopleProfileEditFormItem>
-                        <Label>포트폴리오</Label>
-                        <Button
-                            variant="outline"
-                            width="100%"
-                            height="50px"
-                            css={css`
-                                margin-top: 5px;
-                            `}
-                        >
-                            + 포트폴리오 파일 첨부하기
-                        </Button>
-                    </PeopleProfileEditFormItem>
+                        <PeopleProfileEditFormItem>
+                            <Label>기술스택</Label>
+                            <TechStackSelector techStack={techStack} width="100$" height="350px" />
+                        </PeopleProfileEditFormItem>
 
-                    <PeopleProfileEditFormItem>
-                        <Button variant="primary" width="100%" height="50px">
-                            프로필 저장하기
-                        </Button>
-                    </PeopleProfileEditFormItem>
-                </PeopleProfileEditForm>
-            </PeopleProfileEditPageContainer>
-        </PeopleProfileEditPageWrapper>
-    );
-}
+                        <PeopleProfileEditFormItem>
+                            <Label>포트폴리오</Label>
+                            <Button
+                                variant="outline"
+                                width="100%"
+                                height="50px"
+                                css={css`
+                                    margin-top: 5px;
+                                `}
+                                onClick={handleAddPortfolio}
+                            >
+                                + 포트폴리오 파일 첨부하기
+                            </Button>
+                        </PeopleProfileEditFormItem>
+
+                        <PeopleProfileEditFormItem>
+                            <Button variant="primary" width="100%" height="50px" onClick={handleEditBtnClicked}>
+                                프로필 저장하기
+                            </Button>
+                        </PeopleProfileEditFormItem>
+                    </PeopleProfileEditForm>
+                </PeopleProfileEditPageContainer>
+            </PeopleProfileEditPageWrapper>
+        );
+    },
+);
+
+export default PeopleProfileEditPage;

--- a/src/services/people/people.service.ts
+++ b/src/services/people/people.service.ts
@@ -1,11 +1,37 @@
+import { toast } from "react-toastify";
+
+import { AxiosError } from "axios";
+
 import { api } from "@/config/axios";
 
-import { ReadPeopleResponseBody } from "./people.types";
+import {
+    ReadPeopleResponseBody,
+    RegisterPeopleProfileRequestBody,
+    RegisterPeopleProfileResponseBody,
+} from "./people.types";
 
 export const peopleService = {
     readPeople: async (page = 0, size = 10, sort = "peopleId,desc") => {
         const response = await api.get<ReadPeopleResponseBody>(`/people?page=${page}&size=${size}&sort=${sort}`);
         console.log(response.data.data);
         return response.data.data;
+    },
+    registerPeopleProfile: async (body: RegisterPeopleProfileRequestBody) => {
+        const request = async () => {
+            const response = await api.post<RegisterPeopleProfileResponseBody>(`/people/me/profile`, body);
+
+            if (response instanceof AxiosError) {
+                const status = response.response?.status;
+                if (status === 400) throw new Error("필수항목을 입력해주세요");
+                if (status === 404) throw new Error("등록된 피플정보가 없습니다. 피플 정보를 먼저 등록해주세요");
+            }
+            return response.data;
+        };
+
+        return toast.promise(request, {
+            pending: "피플 프로필 등록 중입니다",
+            success: "피플 프로필 등록 성공!",
+            error: "피플 프로필 등록 실패",
+        });
     },
 };

--- a/src/services/people/people.types.ts
+++ b/src/services/people/people.types.ts
@@ -32,3 +32,22 @@ export interface ReadPeopleResponseBody {
         };
     };
 }
+
+export interface RegisterPeopleProfileRequestBody {
+    education: {
+        school: string;
+        major: string;
+    };
+    activityArea: string;
+    introduction: string;
+    techStacks: string[];
+    portfolios: {
+        description: string;
+        url: string;
+    }[];
+    hashtags: string[];
+}
+
+export interface RegisterPeopleProfileResponseBody {
+    status: number;
+}

--- a/src/services/people/usePeopleProfileEdit.tsx
+++ b/src/services/people/usePeopleProfileEdit.tsx
@@ -1,0 +1,58 @@
+import { useCallback, useRef, useState } from "react";
+
+import { useHashTag } from "@/hooks/useHashTag";
+import { useTechStack } from "@/hooks/useTechStack";
+
+// import { queryClient } from "@/config/query";
+import { peopleService } from "./people.service";
+import { useMutation } from "@tanstack/react-query";
+
+export const usePeopleProfileEdit = () => {
+    const schoolRef = useRef<HTMLInputElement | null>(null);
+    const majorRef = useRef<HTMLInputElement | null>(null);
+    const activityAreaRef = useRef<HTMLInputElement | null>(null);
+    const introductionRef = useRef<HTMLTextAreaElement | null>(null);
+
+    const [portfolio, setPortFolio] = useState<
+        {
+            description: string;
+            url: string;
+        }[]
+    >([]);
+
+    const { state } = useTechStack();
+    const { hashtag } = useHashTag();
+
+    const mutation = useMutation({
+        mutationFn: () =>
+            peopleService.registerPeopleProfile({
+                education: {
+                    school: schoolRef.current?.value as string,
+                    major: majorRef.current?.value as string,
+                },
+                activityArea: activityAreaRef.current?.value as string,
+                introduction: introductionRef.current?.value as string,
+                techStacks: state.selected.map((selectedItem) => selectedItem.value),
+                portfolios: portfolio,
+                hashtags: hashtag,
+            }),
+        onSuccess: () => {
+            // TODO: 피플 프로필 관련 Query Key Invalidation
+            // queryClient.invalidateQueries();
+        },
+    });
+
+    const handleEditBtnClicked = useCallback(() => {
+        mutation.mutate();
+    }, [mutation]);
+
+    const handleAddPortfolio = useCallback(() => {
+        // TODO: 포트폴리오 파일 업로드 API 구현 완료시 수정 필요
+        const description = window.prompt("포트폴리오 내용을 입력해주세요") as string;
+        const url = window.prompt("포트폴리오 URL 을 입력해주세요") as string;
+
+        setPortFolio((portfolio) => [...portfolio, { description: description, url: url }]);
+    }, []);
+
+    return { schoolRef, majorRef, activityAreaRef, introductionRef, handleAddPortfolio, handleEditBtnClicked };
+};


### PR DESCRIPTION
## ✨ 구현한 기능


- `AccordionProvider` 와 `TechStackProvider` 컴포넌트의 children props 를 optional 로 변경했습니다
- `Providers[]` 로 감싼 `WrappedComponent` 를 리턴하는 `withProvider` 고차 컴포넌트를 구현하였습니다

```tsx
import { cloneElement } from "react";

export const withProviders = <Props extends object>(
    providers: React.ReactElement[],
    Component: React.ComponentType<Props>,
) => {
    return (props: Props) => {
        const ProvidersWrappedComponent = providers.reduceRight(
            (providers, provider) => {
                return cloneElement(provider, {}, providers);
            },
            <Component {...props} />,
        );
        return ProvidersWrappedComponent;
    };
};
```

- 피플 프로필 편집 API 를 연동하였습니다
- `TextArea` 컴포넌트에서 ref 를 `React.forwardRef` 로 HTMLTextAreaElement 로 전달하도록 변경하였습니다
- `ProfileHashTag` 컴포넌트에서 내부적으로만 관리되던 입력된 해시태그 상태를 React Context 를 사용해 관리하도록 변경하였습니다

## 📢 논의하고 싶은 내용

- Axios 관련 예외처리시 중복되는 코드가 발생합니다. Builder 패턴 또는 함수형으로 ExceptionHandler 를 구현해 리팩토링 하는것이 좋아 보입니다. 어떻게 생각하시나요?

```ts
    registerPeopleProfile: async (body: RegisterPeopleProfileRequestBody) => {
        const request = async () => {
            const response = await api.post<RegisterPeopleProfileResponseBody>(`/people/me/profile`, body);

            if (response instanceof AxiosError) {
                const status = response.response?.status;
                if (status === 400) throw new Error("필수항목을 입력해주세요");
                if (status === 404) throw new Error("등록된 피플정보가 없습니다. 피플 정보를 먼저 등록해주세요");
            }
            return response.data;
        };

        return toast.promise(request, {
            pending: "피플 프로필 등록 중입니다",
            success: "피플 프로필 등록 성공!",
            error: "피플 프로필 등록 실패",
        });
    },
```

- 기타란에 `ContextProvider` 를 페이지 단에서 처리할 더 좋은 방법이 있다면 의견 제시해주시면 감사드리겠습니다

## 🎸 기타

- 피플 프로필 등록 API 를 연동하기 위해서 `PeopleProfileEditPage` 에서 학교, 전공 ... 등의 정보를 가져오고, `TechStackProvider` 내부에 있는 Context 를 가져와야 합니다
- 하지만, TechStackProvider 는 `PeopleProfileEditPage` 내부에 감싸져 있어, 페이지 단에서 해당 Context 를 가져올시 `useTechStack 은 TechStackProvider 내부에서 사용되어야 합니다` 에러를 throw 합니다

```tsx
export default function PeopleProfileEditPage() {
     const { selected } = useTechStack();
     // Error: useTechStack 은 TechStackProvider 내부에서 사용되어야 합니다

     return <PeopleProfileEditPageWrapper>
          //  ... 중략

          <TeckStackProvider>
                <TechStackSelector />
          </TeckStackProvider>

          //  ... 중략
     <PeopleProfileEditPageWrapper>
}
```

- 이를 해결하기 위해 몇가지의 방법을 생각할 수 있습니다

1. `<PeopleProfileEditPage/>` 컴포넌트를 `<TechStackProvider/>` 로 한번 더 감싼다

> 가장 간단하게 해결할 수 있는 방법이라고 생각되지만, 더 많은 ContextProvider 가 페이지 컴포넌트를 감싸야 할 때를 고려하면,
> 코드의 가독성이 떨어질것으로 생각됩니다

2. Router 단에서 전역에 `<TechStackProvider/>` 로 감싼다

> 전역에서 관리할 수 있어, 따로 페이지를 Provider 로 감싸지 않아도 된다는 장점이 있습니다
> Redux 를 사용하지 않고 Context API 로 뺀 의미가 사라진다는 점과, 해당 Provider 를 사용하지 않는 컴포넌트가 마운트 시에도
> Context 가 추가적인 메모리 공간을 차지한다는 단점이 있습니다

3. 고차 컴포넌트를 사용해 Provider 로 감싼 컴포넌트를 리턴하는 `withProviders` HOC 를 구현한다

```tsx
const WrappedPageComponent = withProviders(
     [
         <ProviderA/>
         <ProviderB/>
         <ProviderC/>
     ],
     function PageComponent() {
         return <></>
     }
)

export default WrappedPageComponent;
```

> 해당 페이지에 필요한 Provider 들을 상단에서 명시적으로 관리할 수 있다는 장점이 있습니다

💪 추가적인, 더 좋은 방법이 있다면 함께 고민하고 의견 나눠봅시다