### PR TITLE
GETP-212 feat: 프로젝트 지원하기 API 연동

### DIFF
--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,0 +1,52 @@
+import { useRef, useState } from "react";
+
+import { useProjectApply } from "@/services/project/useProjectApply";
+
+interface IFile {
+    name: string;
+    url: string;
+}
+
+const useFileUpload = () => {
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const [portfolios, setPortfolios] = useState<IFile[]>([]);
+    const { setAttachmentFiles } = useProjectApply();
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const selectedFiles = e.target.files;
+        if (selectedFiles) {
+            const newFiles = Array.from(selectedFiles).map((file) => ({
+                name: file.name,
+                url: URL.createObjectURL(file),
+            }));
+
+            setPortfolios((prevFiles) => {
+                const updatedFiles = [...prevFiles, ...newFiles];
+                setAttachmentFiles(updatedFiles.map((file) => file.name));
+                return updatedFiles;
+            });
+        }
+    };
+
+    const handleDelete = (url: string) => {
+        setPortfolios((prevFiles) => {
+            const updatedFiles = prevFiles.filter((file) => file.url !== url);
+            setAttachmentFiles(updatedFiles.map((file) => file.name));
+            return updatedFiles;
+        });
+    };
+
+    const handleButtonClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    return {
+        fileInputRef,
+        portfolios,
+        handleFileChange,
+        handleDelete,
+        handleButtonClick,
+    };
+};
+
+export default useFileUpload;

--- a/src/pages/people/PeopleDetailPage.style.tsx
+++ b/src/pages/people/PeopleDetailPage.style.tsx
@@ -137,22 +137,45 @@ export const BadgeContainer = styled.div`
     gap: 8px;
 `;
 
-export const PortfolioCard = styled.button`
+export const NameContainer = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 20px;
+`;
+
+export const PortfolioCard = styled.li`
     width: 100%;
     height: 54px;
 
     display: flex;
-    justify-content: flex-start;
+    justify-content: space-between;
     align-items: center;
 
-    padding-left: 10px;
+    padding: 0px 20px;
     border-radius: 12px;
+    box-sizing: border-box;
 
     background-color: #f9fafa;
 
     font-size: 14px;
+    font-weight: normal;
+    text-decoration: none;
+
+    cursor: pointer;
+`;
+
+export const OpenButton = styled.a`
+    color: #476ff1;
     font-weight: bold;
-    text-decoration: underline;
+    text-decoration: none;
+`;
+
+export const DeleteButton = styled.button`
+    background-color: transparent;
+    &:hover {
+        transform: scale(1.15);
+        cursor: pointer;
+    }
 `;
 
 export const PortfolioContainer = styled.div`

--- a/src/pages/project/ProjectApplyPage.style.ts
+++ b/src/pages/project/ProjectApplyPage.style.ts
@@ -1,0 +1,27 @@
+import { vertical_center } from "@/styles/utils";
+
+import styled from "@emotion/styled";
+
+export const HashTagTitleContainer = styled.h4`
+    width: 100%;
+    margin-bottom: 27px;
+`;
+
+export const DateInput = styled.input`
+    width: 100%;
+    height: 50px;
+    padding: 15px 20px 15px 15px;
+
+    ${vertical_center}
+    align-items: space-between;
+
+    border-radius: 12px;
+    background-color: #f9fafa;
+    cursor: pointer;
+
+    gap: 20px;
+`;
+
+export const FileInput = styled.input`
+    display: none;
+`;

--- a/src/pages/project/ProjectApplyPage.tsx
+++ b/src/pages/project/ProjectApplyPage.tsx
@@ -10,6 +10,8 @@ import {
     ProfileHashTagItem,
 } from "@/components/people/ProfileHashTag.style";
 
+import { vertical_center } from "@/styles/utils";
+
 import {
     PeopleDetailWrapper,
     ProfileContainer,
@@ -20,7 +22,6 @@ import {
     ResponsiveMobileHeading,
     ResponsivePCHeading,
 } from "../people/PeopleDetailPage.style";
-import DropdownButton from "./DropdownButton";
 import styled from "@emotion/styled";
 
 const HashTagTitleContainer = styled.h4`
@@ -28,25 +29,40 @@ const HashTagTitleContainer = styled.h4`
     margin-bottom: 27px;
 `;
 
+const DateInput = styled.input`
+    width: 100%;
+    height: 50px;
+    padding: 15px 20px 15px 15px;
+
+    ${vertical_center}
+    align-items: space-between;
+
+    border-radius: 12px;
+    background-color: #f9fafa;
+    cursor: pointer;
+
+    gap: 20px;
+`;
+
 const ProjectApplyPage = () => {
-    const [selectedStart, setSelectedStart] = useState<string | null>(null);
-    const [selectedEnd, setSelectedEnd] = useState<string | null>(null);
+    const [startDate, setStartDate] = useState<string>("");
+    const [endDate, setEndDate] = useState<string>("");
 
     const hashtags = ["설계", "기획", "서류작업"];
     const portfolios = ["포트폴리오1", "포트폴리오2"];
-    const dateList = [
-        "2024-08-05",
-        "2024-08-10",
-        "2024-08-12",
-        "2024-08-15",
-        "2024-08-18",
-        "2024-08-20",
-        "2024-08-23",
-        "2024-08-24",
-        "2024-08-25",
-        "2024-08-28",
-        "2024-08-30",
-    ];
+
+    const selectStartDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const date = e.target.value;
+        setStartDate(date);
+    };
+
+    const selectEndDate = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const date = e.target.value;
+        setEndDate(date);
+    };
+
+    console.log(startDate);
+    console.log(endDate);
 
     return (
         <PeopleDetailWrapper>
@@ -81,11 +97,10 @@ const ProjectApplyPage = () => {
                     <Text size="m" color="secondary" weight="bold">
                         희망 작업 시작일
                     </Text>
-                    <DropdownButton
-                        list={dateList}
-                        selectedItem={selectedStart}
-                        setSelectedItem={setSelectedStart}
-                        defaultValue="희망하는 작업 시작일을 선택해 주세요.(0000-00-00)"
+                    <DateInput
+                        type="date"
+                        placeholder="희망하는 작업 시작일을 선택해 주세요."
+                        onChange={selectStartDate}
                     />
                 </TextboxContainer>
 
@@ -93,11 +108,10 @@ const ProjectApplyPage = () => {
                     <Text size="m" color="secondary" weight="bold">
                         희망 작업 마감일
                     </Text>
-                    <DropdownButton
-                        list={dateList}
-                        selectedItem={selectedEnd}
-                        setSelectedItem={setSelectedEnd}
-                        defaultValue="희망하는 작업 마감일을 선택해 주세요.(0000-00-00)"
+                    <DateInput
+                        type="date"
+                        placeholder="희망하는 작업 시작일을 선택해 주세요."
+                        onChange={selectEndDate}
                     />
                 </TextboxContainer>
 

--- a/src/pages/project/ProjectApplyPage.tsx
+++ b/src/pages/project/ProjectApplyPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef } from "react";
 
 import { TextArea, Button } from "principes-getp";
 
@@ -9,6 +9,8 @@ import {
     ProfileHashTagContainer,
     ProfileHashTagItem,
 } from "@/components/people/ProfileHashTag.style";
+
+import { useProjectApply } from "@/services/project/useProjectApply";
 
 import { vertical_center } from "@/styles/utils";
 
@@ -45,8 +47,7 @@ const DateInput = styled.input`
 `;
 
 const ProjectApplyPage = () => {
-    const [startDate, setStartDate] = useState<string>("");
-    const [endDate, setEndDate] = useState<string>("");
+    const { setStartDate, setEndDate, descriptionRef, setAttachmentFiles, handleApplyBtnClicked } = useProjectApply();
 
     const hashtags = ["설계", "기획", "서류작업"];
     const portfolios = ["포트폴리오1", "포트폴리오2"];
@@ -60,9 +61,6 @@ const ProjectApplyPage = () => {
         const date = e.target.value;
         setEndDate(date);
     };
-
-    console.log(startDate);
-    console.log(endDate);
 
     return (
         <PeopleDetailWrapper>
@@ -120,6 +118,7 @@ const ProjectApplyPage = () => {
                         지원 내용
                     </Text>
                     <TextArea
+                        ref={descriptionRef}
                         variant="secondary"
                         width="100%"
                         height="261px"

--- a/src/pages/project/ProjectApplyPage.tsx
+++ b/src/pages/project/ProjectApplyPage.tsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 import { TextArea, Button } from "principes-getp";
 
 import { Text } from "@/components/__common__/typography/Text";
@@ -10,9 +8,11 @@ import {
     ProfileHashTagItem,
 } from "@/components/people/ProfileHashTag.style";
 
+import useFileUpload from "@/hooks/useFileUpload";
+
 import { useProjectApply } from "@/services/project/useProjectApply";
 
-import { vertical_center } from "@/styles/utils";
+import deleteIcon from "@/assets/people/close.svg";
 
 import {
     PeopleDetailWrapper,
@@ -23,34 +23,17 @@ import {
     PortfolioCard,
     ResponsiveMobileHeading,
     ResponsivePCHeading,
+    NameContainer,
+    OpenButton,
+    DeleteButton,
 } from "../people/PeopleDetailPage.style";
-import styled from "@emotion/styled";
-
-const HashTagTitleContainer = styled.h4`
-    width: 100%;
-    margin-bottom: 27px;
-`;
-
-const DateInput = styled.input`
-    width: 100%;
-    height: 50px;
-    padding: 15px 20px 15px 15px;
-
-    ${vertical_center}
-    align-items: space-between;
-
-    border-radius: 12px;
-    background-color: #f9fafa;
-    cursor: pointer;
-
-    gap: 20px;
-`;
+import { HashTagTitleContainer, DateInput, FileInput } from "./ProjectApplyPage.style";
 
 const ProjectApplyPage = () => {
-    const { setStartDate, setEndDate, descriptionRef, setAttachmentFiles, handleApplyBtnClicked } = useProjectApply();
+    const { setStartDate, setEndDate, descriptionRef, handleApplyBtnClicked } = useProjectApply();
+    const { fileInputRef, portfolios, handleFileChange, handleDelete, handleButtonClick } = useFileUpload();
 
     const hashtags = ["설계", "기획", "서류작업"];
-    const portfolios = ["포트폴리오1", "포트폴리오2"];
 
     const selectStartDate = (e: React.ChangeEvent<HTMLInputElement>) => {
         const date = e.target.value;
@@ -130,18 +113,37 @@ const ProjectApplyPage = () => {
                     <Text size="m" color="secondary" weight="bold">
                         포트폴리오
                     </Text>
-                    <PortfolioContainer>
-                        {portfolios.map((portfolio) => (
-                            <PortfolioCard key={portfolio}>{portfolio}</PortfolioCard>
-                        ))}
-                    </PortfolioContainer>
+                    {portfolios.length > 0 && (
+                        <PortfolioContainer>
+                            {portfolios.map((portfolio, index) => (
+                                <PortfolioCard key={index}>
+                                    <NameContainer>
+                                        <DeleteButton onClick={() => handleDelete(portfolio.url)}>
+                                            <img src={deleteIcon} alt="delete" />
+                                        </DeleteButton>
+                                        {portfolio.name}
+                                    </NameContainer>
+                                    <OpenButton href={portfolio.url} target="_blank" rel="noopener noreferrer">
+                                        파일 열기
+                                    </OpenButton>
+                                </PortfolioCard>
+                            ))}
+                        </PortfolioContainer>
+                    )}
                 </TextboxContainer>
 
                 <TextboxContainer>
-                    <Button variant="outline" width="100%" height="50px">
+                    <FileInput
+                        placeholder="포트폴리오"
+                        type="file"
+                        accept=".pdf"
+                        ref={fileInputRef}
+                        onChange={handleFileChange}
+                    />
+                    <Button onClick={handleButtonClick} variant="outline" width="100%" height="50px">
                         + 포트폴리오 파일 첨부하기
                     </Button>
-                    <Button variant="primary" width="100%" height="50px">
+                    <Button onClick={handleApplyBtnClicked} variant="primary" width="100%" height="50px">
                         프로젝트 지원하기
                     </Button>
                 </TextboxContainer>

--- a/src/services/project/service.ts
+++ b/src/services/project/service.ts
@@ -8,13 +8,12 @@ import { ApplyProjectRequestBody } from "./types";
 
 export const projectService = {
     applyProjectById: async (body: ApplyProjectRequestBody, id = 1) => {
+        if (!isRequestBodyValid(body)) throw new Error("모든 정보를 입력해주세요.");
         const request = async () => {
-            if (!isRequestBodyValid(body)) throw new Error("모든 정보를 입력해주세요.");
-
-            await api.post<ApplyProjectRequestBody>(`/get-p/v2/projects/${id}/applications`, body);
+            return await api.post<ApplyProjectRequestBody>(`/projects/${id}/applications`, body);
         };
 
-        return toast.promise(request, {
+        return toast.promise(request(), {
             pending: "프로젝트 지원 정보를 등록 중입니다.",
             success: "프로젝트에 성공적으로 지원되었습니다.",
             error: "프로젝트 지원에 실패하였습니다. 다시 시도해 주세요.",

--- a/src/services/project/service.ts
+++ b/src/services/project/service.ts
@@ -1,1 +1,23 @@
-export const projectService = {};
+import { toast } from "react-toastify";
+
+import { api } from "@/config/axios";
+
+import { isRequestBodyValid } from "@/utils/validation";
+
+import { ApplyProjectRequestBody } from "./types";
+
+export const projectService = {
+    applyProjectById: async (body: ApplyProjectRequestBody, id = 1) => {
+        const request = async () => {
+            if (!isRequestBodyValid(body)) throw new Error("모든 정보를 입력해주세요.");
+
+            await api.post<ApplyProjectRequestBody>(`/get-p/v2/projects/${id}/applications`, body);
+        };
+
+        return toast.promise(request, {
+            pending: "프로젝트 지원 정보를 등록 중입니다.",
+            success: "프로젝트에 성공적으로 지원되었습니다.",
+            error: "프로젝트 지원에 실패하였습니다. 다시 시도해 주세요.",
+        });
+    },
+};

--- a/src/services/project/types.ts
+++ b/src/services/project/types.ts
@@ -1,0 +1,8 @@
+export interface ApplyProjectRequestBody {
+    expectedDuration: {
+        startDate: string;
+        endDate: string;
+    };
+    description: string;
+    attchmentFiles: string[];
+}

--- a/src/services/project/types.ts
+++ b/src/services/project/types.ts
@@ -4,5 +4,5 @@ export interface ApplyProjectRequestBody {
         endDate: string;
     };
     description: string;
-    attchmentFiles: string[];
+    attachmentFiles: string[];
 }

--- a/src/services/project/useProjectApply.tsx
+++ b/src/services/project/useProjectApply.tsx
@@ -1,0 +1,29 @@
+import { useCallback, useState, useRef } from "react";
+
+import { projectService } from "./service";
+import { useMutation } from "@tanstack/react-query";
+
+export const useProjectApply = () => {
+    const [startDate, setStartDate] = useState<string>("");
+    const [endDate, setEndDate] = useState<string>("");
+    const descriptionRef = useRef<HTMLTextAreaElement | null>(null);
+    const [attachmentFiles, setAttachmentFiles] = useState<string[]>([]);
+
+    const mutation = useMutation({
+        mutationFn: () =>
+            projectService.applyProjectById({
+                expectedDuration: {
+                    startDate: startDate,
+                    endDate: endDate,
+                },
+                description: descriptionRef.current?.value as string,
+                attachmentFiles: attachmentFiles,
+            }),
+    });
+
+    const handleApplyBtnClicked = useCallback(() => {
+        mutation.mutate();
+    }, [mutation]);
+
+    return { setStartDate, setEndDate, descriptionRef, setAttachmentFiles, handleApplyBtnClicked };
+};


### PR DESCRIPTION
## ✨ 구현한 기능

- 작업 시작일/마감일 드롭다운리스트 -> input type = date로 변경
- 프로젝트 지원하기 API 연동
- 파일 첨부 기능 구현

## 📢 논의하고 싶은 내용

- 파일 첨부: 포트폴리오를 노션 링크, 깃허브 링크와 같이 웹페이지 링크로 받을 것인지 vs pdf 파일과 같이 파일 형태로 받을 것인지 -> 파일 형태로 받을 경우 URL을 blob 객체로 저장해서 보내야 하는데, 현재 api 명세서에는 파일을 string으로 받게 되어 있어 api 수정이 필요할 것 같습니다. 우선은 파일명을 보내도록 구현해두었습니다.
- api 요청 시 console.log로는 파일명 배열이 잘 출력되는데 요청은 계속 빈 배열로 갑니다. 원인을 모르겠습니다..
- 위 이유 때문인지 api 요청이 계속 실패하는데 이것도 원인을 모르겠습니다..

## 🎸 기타

-
