### PR TITLE
GETP-134 Fix: 프로필 사진 업로드시 프로필 정보를 다시 불러오도록 설정

### DIFF
--- a/src/components/__common__/display/Profile.tsx
+++ b/src/components/__common__/display/Profile.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, ChangeEvent } from "react";
+import { useDispatch } from "react-redux";
 
 import { memberService } from "@/services/member/service";
 
@@ -6,8 +7,12 @@ import editIcon from "@/assets/common/edit.svg";
 import defaultImg from "@/assets/common/profile.svg";
 
 import { EditBtn, InputFile, PencilIcon, ProfileContainer, ProfileImage } from "./Profile.style";
+import { RootDispatch } from "@/store/store";
+import { updateProfileThunkAction } from "@/store/thunk/auth.thunk";
 
 export const Profile = () => {
+    const dispatch: RootDispatch = useDispatch();
+
     const [profileImage, setProfileImage] = useState(defaultImg);
     const inputFileRef = useRef<HTMLInputElement>(null);
 
@@ -22,7 +27,9 @@ export const Profile = () => {
             };
             reader.readAsDataURL(file);
 
-            await memberService.registerProfileImage(inputFileRef.current.files[0]);
+            memberService.registerProfileImage(inputFileRef.current.files[0]).then(() => {
+                dispatch(updateProfileThunkAction());
+            });
         }
     };
     return (

--- a/src/components/__common__/display/Profile.tsx
+++ b/src/components/__common__/display/Profile.tsx
@@ -16,7 +16,7 @@ export const Profile = () => {
     const [profileImage, setProfileImage] = useState(defaultImg);
     const inputFileRef = useRef<HTMLInputElement>(null);
 
-    const handleImageUpload = async (e: ChangeEvent<HTMLInputElement>) => {
+    const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files.length > 0 && inputFileRef.current && inputFileRef.current.files) {
             const file = e.target.files[0];
             const reader = new FileReader();

--- a/src/store/slice/auth.slice.ts
+++ b/src/store/slice/auth.slice.ts
@@ -54,6 +54,12 @@ const authSlice = createSlice({
             state.accessToken = action.payload.accessToken;
             state.refreshToken = action.payload.refreshToken;
         },
+        updateProfileImageUri: (state, action: PayloadAction<string>) => {
+            state.profileImageUri = action.payload;
+        },
+        updateNickName: (state, action: PayloadAction<string>) => {
+            state.nickname = action.payload;
+        },
     },
 });
 

--- a/src/store/thunk/auth.thunk.ts
+++ b/src/store/thunk/auth.thunk.ts
@@ -42,3 +42,13 @@ export const signInThunkAction = (email: string, password: string, navigate: Nav
         navigate("/");
     };
 };
+
+export const updateProfileThunkAction = () => {
+    return async (dispatch: RootDispatch) => {
+        const memberResponse = await memberService.readMemberProfile();
+        const { nickname, profileImageUri } = memberResponse.data.data;
+
+        dispatch(authAction.updateProfileImageUri(profileImageUri));
+        dispatch(authAction.updateNickName(nickname));
+    };
+};


### PR DESCRIPTION
## ✨ 구현한 기능

- 프로필 사진 업로드시 `/member/me` API 를 재호출 후, updateProfileThunkActions 를 사용하여,  Redux 에 저장하도록 구현하였습니다

## 📢 논의하고 싶은 내용

@scv1702 

```json
{
    "status": 201,
    "data": {
        "profileImageUri": "https://storage.principes.xyz/1/profile/c88eee22-b572-4128-ad8a-758709a3bb4d.jpeg"
    }
}
```

![image](https://github.com/user-attachments/assets/5d9e6727-a193-4b0c-842e-a6fb80e12686)

프로필 사진 업로드 후 응답은 성공했으나, `profileImageUri` 에 대한 리소스를 찾을 수 없다고 뜹니다


## 🎸 기타

-
