### PR TITLE
GETP-215 Feature: 의뢰자 등록 및 수정 API 연동

### DIFF
--- a/.vscode/workspace.code-snippets
+++ b/.vscode/workspace.code-snippets
@@ -3,24 +3,40 @@
         "prefix": ["!styled"],
         "body": ["import styled from \"@emotion/styled\";"],
     },
-    "StoryBook" : {
-        "prefix" : ["!story"],
+    "StoryBook": {
+        "prefix": ["!story"],
         "body": [
             "import type { Meta, StoryObj } from \"@storybook/react\";",
             "",
-            "const meta = {"
+            "const meta = {",
             "    title: /*여기에 스토리 제목 입력 (/ 를 사용하면 그룹으로 묶입니다!)*/,",
             "    component: /* 여기에 컴포넌트 입력 */,",
             "} satisfies Meta<typeof /* 여기에 컴포넌트 입력 */>;",
             "",
-            "export default meta;"
-            "type Story = StoryObj<typeof meta>;"
+            "export default meta;",
+            "type Story = StoryObj<typeof meta>;",
             "",
-            "export const /* 여기에 스토리 이름 입력 */ : Story = {"
-            "    args: {"
+            "export const /* 여기에 스토리 이름 입력 */ : Story = {",
+            "    args: {",
             "       /* 여기에 Props 입력 */",
-            "    },"
-            "};"
-        ]
-    }
+            "    },",
+            "};",
+        ],
+    },
+    "API": {
+        "prefix": "!api",
+        "body": [
+            "NAME : async () => {",
+            "   const request = async () => {",
+            "       const response = await api.${1:METHOD}(${2:ENDPOINT});",
+            "       return new ExceptionHandler.Builder(response).addCase(${3:ERR_CODE},${4:ERR_MESSAGE}).activate();",
+            "   }",
+            "   return toast.promise(request, {",
+            "       success: ${5:SUCCESS_MESSAGE},",
+            "       pending: ${6:PENDING_MESSAGE},",
+            "       error: RenderToastFromDerivedError",
+            "   });",
+            "}",
+        ],
+    },
 }

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -48,8 +48,22 @@ export const Router = () => {
                     }
                 />
 
-                <Route path="client/register" element={<RegisterClientPage />} />
-                <Route path="client/edit" element={<EditClientPage />} />
+                <Route
+                    path="client/register"
+                    element={
+                        <RouteGuard role={MemberType.ROLE_CLIENT}>
+                            <RegisterClientPage />
+                        </RouteGuard>
+                    }
+                />
+                <Route
+                    path="client/edit"
+                    element={
+                        <RouteGuard role={MemberType.ROLE_CLIENT}>
+                            <EditClientPage />
+                        </RouteGuard>
+                    }
+                />
 
                 <Route path="project/apply" element={<ProjectApplyPage />} />
 

--- a/src/constants/profileMenuItems.ts
+++ b/src/constants/profileMenuItems.ts
@@ -7,7 +7,7 @@ export interface IProfileMenuItem {
 }
 
 export const profileMenu = (memberType: MemberType | null): IProfileMenuItem[] => {
-    if (memberType === MemberType.ROLE_PEOPLE) {
+    if (memberType === MemberType.ROLE_CLIENT) {
         return [
             {
                 id: 1,

--- a/src/pages/client/EditClientPage.tsx
+++ b/src/pages/client/EditClientPage.tsx
@@ -5,6 +5,8 @@ import { Label } from "principes-getp";
 import { Profile } from "@/components/__common__/display/Profile";
 import { Title } from "@/components/__common__/typography/Title";
 
+import { useEditClient } from "@/services/client/useEditClient";
+
 import {
     EditClientPageForm,
     EditClientPageFormItem,
@@ -14,6 +16,8 @@ import {
 import { css } from "@emotion/react";
 
 export default function EditClientPage() {
+    const { nicknameRef, emailRef, phoneNumberRef, handleRegisterBtnClick } = useEditClient();
+
     return (
         <EditClientPageWrapper>
             <Title>의뢰자 정보 수정</Title>
@@ -25,12 +29,13 @@ export default function EditClientPage() {
 
                 <EditClientPageFormItem>
                     <Label>닉네임(필수)</Label>
-                    <Input width="100%" height="40px" placeholder="닉네임을 입력해주세요"></Input>
+                    <Input ref={nicknameRef} width="100%" height="40px" placeholder="닉네임을 입력해주세요"></Input>
                 </EditClientPageFormItem>
 
                 <EditClientPageFormItem>
                     <Label>전화번호(필수)</Label>
                     <Input
+                        ref={phoneNumberRef}
                         width="100%"
                         height="40px"
                         placeholder="전화번호를 입력해주세요('-' 빼고 숫자만 입력)"
@@ -40,6 +45,7 @@ export default function EditClientPage() {
                 <EditClientPageFormItem>
                     <Label>이메일(선택)</Label>
                     <Input
+                        ref={emailRef}
                         width="100%"
                         height="40px"
                         placeholder="의뢰 연락을 받을 다른 이메일이 있는 경우 입력해주세요"
@@ -59,7 +65,7 @@ export default function EditClientPage() {
 
                 <EditClientPageFormItem>
                     <Label>계좌(선택)</Label>
-                    <Input width="100%" height="45px"></Input>
+                    <Input width="100%" height="45px" placeholder=""></Input>
                     <Input width="100%" height="45px"></Input>
                     <Input width="100%" height="45px"></Input>
                 </EditClientPageFormItem>
@@ -72,6 +78,7 @@ export default function EditClientPage() {
                 css={css`
                     margin: 100px 0px;
                 `}
+                onClick={handleRegisterBtnClick}
             >
                 프로필 저장하기
             </Button>

--- a/src/pages/client/RegisterClientPage.tsx
+++ b/src/pages/client/RegisterClientPage.tsx
@@ -7,6 +7,8 @@ import { Paragraph } from "@/components/__common__/typography/Paragraph";
 import { Text } from "@/components/__common__/typography/Text";
 import { Title } from "@/components/__common__/typography/Title";
 
+import { useRegisterClient } from "@/services/client/useRegisterClient";
+
 import {
     RegisterClientPageContainer,
     RegisterClientPageFormItem,
@@ -16,6 +18,8 @@ import {
 import { css } from "@emotion/react";
 
 export default function RegisterClientPage() {
+    const { nicknameRef, emailRef, phoneNumberRef, handleRegisterBtnClick } = useRegisterClient();
+
     return (
         <RegisterClientPageWrapper>
             <Title>의뢰자 정보 등록</Title>
@@ -33,12 +37,13 @@ export default function RegisterClientPage() {
 
                 <RegisterClientPageFormItem>
                     <Label>닉네임(필수)</Label>
-                    <Input width="100%" height="40px" placeholder="닉네임을 입력해주세요"></Input>
+                    <Input ref={nicknameRef} width="100%" height="40px" placeholder="닉네임을 입력해주세요"></Input>
                 </RegisterClientPageFormItem>
 
                 <RegisterClientPageFormItem>
                     <Label>전화번호(필수)</Label>
                     <Input
+                        ref={phoneNumberRef}
                         width="100%"
                         height="40px"
                         placeholder="전화번호를 입력해주세요('-' 빼고 숫자만 입력)"
@@ -48,6 +53,7 @@ export default function RegisterClientPage() {
                 <RegisterClientPageFormItem>
                     <Label>이메일(선택)</Label>
                     <Input
+                        ref={emailRef}
                         width="100%"
                         height="40px"
                         placeholder="의뢰 연락을 받을 다른 이메일이 있는 경우 입력해주세요"
@@ -67,12 +73,13 @@ export default function RegisterClientPage() {
             </RegisterClientPageContainer>
 
             <Button
-                variant="disabled"
+                variant="primary"
                 width="100%"
                 height="50px"
                 css={css`
                     margin: 100px 0px;
                 `}
+                onClick={handleRegisterBtnClick}
             >
                 의뢰자 정보 등록하기
             </Button>

--- a/src/services/client/service.ts
+++ b/src/services/client/service.ts
@@ -1,0 +1,39 @@
+import { toast } from "react-toastify";
+
+import { api } from "@/config/axios";
+
+import { ExceptionHandler } from "@/utils/exception";
+
+import { RenderToastFromDerivedError } from "../exception";
+import { RegisterClientRequestBody, RegisterClientResponseBody } from "./types";
+
+export const clientService = {
+    registerClient: async (body: RegisterClientRequestBody) => {
+        const request = async () => {
+            const response = await api.post<RegisterClientResponseBody>("/client/me", body);
+
+            return new ExceptionHandler.Builder(response)
+                .addCase(500, "의뢰자 정보 등록중 오류가 발생하였습니다. 잠시 후 다시 시도해 주세요")
+                .activate();
+        };
+
+        return toast.promise(request, {
+            success: "의뢰자 정보 등록 완료!",
+            pending: "의뢰자 정보 등록 중입니다",
+            error: RenderToastFromDerivedError,
+        });
+    },
+    editClient: async (body: RegisterClientRequestBody) => {
+        const request = async () => {
+            const response = await api.put<RegisterClientResponseBody>("/client/me", body);
+            return new ExceptionHandler.Builder(response)
+                .addCase(500, "의뢰자 정보 등록중 오류가 발생하였습니다. 잠시 후 다시 시도해 주세요")
+                .activate();
+        };
+        return toast.promise(request, {
+            success: "의뢰자 정보 수정 완료!",
+            pending: "의뢰자 정보 수정 중입니다",
+            error: RenderToastFromDerivedError,
+        });
+    },
+};

--- a/src/services/client/types.ts
+++ b/src/services/client/types.ts
@@ -1,0 +1,19 @@
+import { BaseResponse } from "../types";
+
+export type RegisterClientRequestBody = {
+    nickname: string;
+    email: string;
+    phoneNumber: string;
+    address: {
+        zipcode: string;
+        street: string;
+        detail: string;
+    };
+    bankAccount: {
+        bank: string;
+        accountNumber: string;
+        accountHolder: string;
+    };
+};
+
+export type RegisterClientResponseBody = BaseResponse<{ clientId: number }>;

--- a/src/services/client/useEditClient.tsx
+++ b/src/services/client/useEditClient.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from "react";
+
+import { clientService } from "./service";
+import { useMutation } from "@tanstack/react-query";
+
+export const useEditClient = () => {
+    const nicknameRef = useRef<HTMLInputElement>(null);
+    const emailRef = useRef<HTMLInputElement>(null);
+    const phoneNumberRef = useRef<HTMLInputElement>(null);
+
+    const mutation = useMutation({
+        mutationFn: () =>
+            clientService.editClient({
+                nickname: nicknameRef.current?.value as string,
+                email: emailRef.current?.value as string,
+                phoneNumber: phoneNumberRef.current?.value as string,
+                address: {
+                    zipcode: "",
+                    street: "",
+                    detail: "",
+                },
+                bankAccount: {
+                    bank: "",
+                    accountNumber: "",
+                    accountHolder: "",
+                },
+            }),
+    });
+
+    const handleRegisterBtnClick = useCallback(() => {
+        mutation.mutate();
+    }, [mutation]);
+
+    return { nicknameRef, emailRef, phoneNumberRef, handleRegisterBtnClick };
+};

--- a/src/services/client/useRegisterClient.tsx
+++ b/src/services/client/useRegisterClient.tsx
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from "react";
+
+import { clientService } from "./service";
+import { useMutation } from "@tanstack/react-query";
+
+export const useRegisterClient = () => {
+    const nicknameRef = useRef<HTMLInputElement>(null);
+    const emailRef = useRef<HTMLInputElement>(null);
+    const phoneNumberRef = useRef<HTMLInputElement>(null);
+
+    const mutation = useMutation({
+        mutationFn: () =>
+            clientService.registerClient({
+                nickname: nicknameRef.current?.value as string,
+                email: emailRef.current?.value as string,
+                phoneNumber: phoneNumberRef.current?.value as string,
+                address: {
+                    zipcode: "",
+                    street: "",
+                    detail: "",
+                },
+                bankAccount: {
+                    bank: "",
+                    accountNumber: "",
+                    accountHolder: "",
+                },
+            }),
+    });
+
+    const handleRegisterBtnClick = useCallback(() => {
+        mutation.mutate();
+    }, [mutation]);
+
+    return { nicknameRef, emailRef, phoneNumberRef, handleRegisterBtnClick };
+};


### PR DESCRIPTION
## ✨ 구현한 기능

- 의뢰자 등록 및 수정 API 연동 완료하였습니다
- 프로필 드롭다운 메뉴가 의뢰자/피플 에 따라 올바르지 않게 매칭되는 문제를 해결하였습니다

## 📢 논의하고 싶은 내용

- `/client/me` API 호출시 500 에러가 발생합니다 @wlgns12370 @scv1702 

요청에 해당하는 페이로드는 다음과 같습니다

```json
{
    "nickname":"투슬리스",
    "email":"tkv402@naver.com",
    "phoneNumber":"01048705466",
    "address" : {
        "zipcode":"",
        "street":"",
        "detail":""
    },
    "bankAccount": {
        "bank":"",
        "accountNumber":"",
        "accountHolder":""
    }
}
```

![image](https://github.com/user-attachments/assets/2bf1671e-2d72-44e1-a7f1-3b731f94c3bf)


## 🎸 기타

- VS Code API Code Snippet 을 추가하였습니다

이제 `/services` 에서 `!api` 입력시 다음과 같은 코드가 자동 완성됩니다

```ts
    NAME : async () => {
       const request = async () => {
           const response = await api.METHOD(ENDPOINT);
           return new ExceptionHandler.Builder(response).addCase(ERR_CODE,ERR_MESSAGE).activate();
       }
       return toast.promise(request, {
           success: SUCCESS_MESSAGE,
           pending: PENDING_MESSAGE,
           error: RenderToastFromDerivedError
       });
    }
```