### PR TITLE
Issue #78 Fix : Mobile 크기에서 NavAsideButton 클릭 후 웹 사이즈를 늘리면 NavAsideContainer 취소 불가능 문제 해결

### DIFF
--- a/src/hooks/useNavAside.ts
+++ b/src/hooks/useNavAside.ts
@@ -1,7 +1,9 @@
 import { useLayoutEffect, useRef } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
-import { RootState } from "@/store/store";
+import { useDebouncedScreenSize } from "./useScreenSize";
+import { uiActions } from "@/store/slice/ui.slice";
+import { RootDispatch, RootState } from "@/store/store";
 
 export const useNavAside = () => {
     const backdropRef = useRef<HTMLDivElement>(null);
@@ -10,6 +12,16 @@ export const useNavAside = () => {
     const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const { isNavAsideOpened } = useSelector((state: RootState) => state.ui);
+    const dispatch: RootDispatch = useDispatch();
+
+    const { innerWidth } = useDebouncedScreenSize();
+
+    useLayoutEffect(
+        function closeNavAsideWhenScreenExpands() {
+            if (innerWidth > 768 && isNavAsideOpened) dispatch(uiActions.closeNavAside());
+        },
+        [innerWidth, dispatch, isNavAsideOpened],
+    );
 
     useLayoutEffect(() => {
         if (isNavAsideOpened) {

--- a/src/hooks/useScreenSize.ts
+++ b/src/hooks/useScreenSize.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+export const useDebouncedScreenSize = () => {
+    const [innerWidth, setInnerWidth] = useState<number>(window.innerWidth);
+    const [innerHeight, setInnerHeight] = useState<number>(window.innerHeight);
+
+    useEffect(() => {
+        let timer: ReturnType<typeof setTimeout>;
+
+        const handleResize = (e: Event) => {
+            timer && clearTimeout(timer);
+
+            timer = setTimeout(() => {
+                const target = e.target as Window;
+                setInnerWidth(target.innerWidth);
+                setInnerHeight(target.innerHeight);
+            }, 300);
+        };
+
+        window.addEventListener("resize", handleResize);
+
+        return () => {
+            timer && clearTimeout(timer);
+            window.removeEventListener("resize", handleResize);
+        };
+    }, []);
+
+    return { innerWidth, innerHeight };
+};


### PR DESCRIPTION
## ✨ 구현한 기능

- 스크린 사이즈가 `768px` 이상이고, NavAside 가 열려 있는 경우 닫히도록 수정
- 스크린 사이즈의 `resize` 이벤트가 일어날 때 마다 `innerWidth` , `innerHeight` 값이 업데이트 되어 성능이 저하되는 문제가 발생

## 📢 논의하고 싶은 내용

- 스크린 사이즈의 `resize` 이벤트가 일어날 때 마다 `innerWidth` , `innerHeight` 값이 업데이트 되어 성능이 저하되는 문제가 발생
- `useDebouncedScreenSize` 커스텀 훅을 구현하여 resize 이벤트 발생시 너비, 높이 상태값을 `300ms` 마다 업데이트 하도록 수정

## 🎸 기타

- resolve #78 
