### PR TITLE
GETP-298 Refactor : 피플 목록 페이지, 프로젝트 찾기 페이지 수정

### DIFF
--- a/src/components/people/PeopleSearch.tsx
+++ b/src/components/people/PeopleSearch.tsx
@@ -21,26 +21,22 @@ export interface IPeopleSearch {
     options?: ISortOption[];
     order?: ISortOption;
     onSortChange?: (order: ISortOption) => void;
+    headerText?: string;
 }
 
-export const PeopleSearch = ({ width, height, options, order, onSortChange }: IPeopleSearch) => {
-    const { toggle, handleClick } = useToggle();
+export const PeopleSearch = ({ width, height, options, order, onSortChange, headerText }: IPeopleSearch) => {
+    const { handleClick } = useToggle();
 
     return (
         <PeopleSearchWrapper width={width} height={height}>
             <PeopleSearchHeader>
                 <Text size="m" color="primary" weight="bold">
-                    어떤 피플을 찾으시나요?
+                    {headerText || "어떤 피플을 찾으시나요?"}
                 </Text>
             </PeopleSearchHeader>
             <SearchBar width={width} placeholder="검색어를 입력하세요" />
             <PeopleSearchOptionWrapper>
-                <PeopleSearchCheckBox onClick={handleClick}>
-                    <TotalProjectIcon checked={toggle} />
-                    <Text size="s" color="primary" weight="bold">
-                        전체 프로젝트 보기
-                    </Text>
-                </PeopleSearchCheckBox>
+                <PeopleSearchCheckBox onClick={handleClick}></PeopleSearchCheckBox>
 
                 <PeopleSearchOptionContainer>
                     {options?.map((option) => (

--- a/src/pages/project/ProjectListPage/ProjectListPage.tsx
+++ b/src/pages/project/ProjectListPage/ProjectListPage.tsx
@@ -40,6 +40,7 @@ export default function ProjectListPage() {
                 options={sortOptions}
                 order={sortOrder}
                 onSortChange={handleSortOrder}
+                headerText="어떤 프로젝트를 찾으시나요?"
             />
             <ProjectListContainer>
                 {data && (


### PR DESCRIPTION
## ✨ 구현한 기능

- 피플 목록 페이지에 전체 프로젝트 보기 제거
- 프로젝트 찾기 페이지 문구 확장 가능하도록 수정

## 📢 논의하고 싶은 내용

-

## 🎸 기타

-
