### PR TITLE
GETP-303 Fix: 프로젝트 리스트 수정

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -90,7 +90,7 @@ export const Router = () => {
                     }
                 />
 
-                <Route path="project/:id" element={<ProjectDetailPage />} />
+                <Route path="projects/:id" element={<ProjectDetailPage />} />
 
                 <Route path="project/:id/meetings" element={<MeetingRequestPage />} />
                 <Route path="*" element={<NotFoundPage />} />

--- a/src/components/project/ProjectCard/index.story.tsx
+++ b/src/components/project/ProjectCard/index.story.tsx
@@ -23,7 +23,92 @@ export const Default: Story = {
         },
         hashtags: ["#개발", "#웹 개발", "#React"],
         description:
+            "React를 이용해 간단한 캘린더를 제작해주세요. 스토리 보드 및 기획은 이미 완성되어 있는 상태이며, 개발자의 시안 수령 및 구현만이 남아 있습니다. 자세한 api명세와 데이터베이스 관리에 대해서는 논의가 더 필요합니다.",
+        status: "PREPARING", // 올바른 상태
+    },
+};
+
+export const PREPARING: Story = {
+    args: {
+        title: "간단한 캘린더 제작",
+        payment: 500000,
+        applicantsCount: 4,
+        estimatedDays: 80,
+        applicationDuration: {
+            startDate: "2023-12-31",
+            endDate: "2024-08-12",
+        },
+        hashtags: ["#개발", "#웹 개발", "#React"],
+        description:
+            "React를 이용해 간단한 캘린더를 제작해주세요. 스토리 보드 및 기획은 이미 완성되어 있는 상태이며, 개발자의 시안 수령 및 구현만이 남아 있습니다. 자세한 api명세와 데이터베이스 관리에 대해서는 논의가 더 필요합니다.",
+        status: "PREPARING", // 올바른 상태
+    },
+};
+
+export const APPLYING: Story = {
+    args: {
+        title: "간단한 캘린더 제작",
+        payment: 500000,
+        applicantsCount: 4,
+        estimatedDays: 80,
+        applicationDuration: {
+            startDate: "2023-12-31",
+            endDate: "2024-08-12",
+        },
+        hashtags: ["#개발", "#웹 개발", "#React"],
+        description:
             "React를 이용해 간단한 캘린더를 제작해주세요. 스토리 보드 및 기획은 이미 완성되어 있는 상태이며, 개발자의 시안 수령 및 구현만이 남아 있습니다. 자세한 api명세와 데이터베이스 관리에 대해서는 논의가 더 필요합니다. ",
-        status: "모집중",
+        status: "APPLYING",
+    },
+};
+
+export const PROGRESSING: Story = {
+    args: {
+        title: "간단한 캘린더 제작",
+        payment: 500000,
+        applicantsCount: 4,
+        estimatedDays: 80,
+        applicationDuration: {
+            startDate: "2023-12-31",
+            endDate: "2024-08-12",
+        },
+        hashtags: ["#개발", "#웹 개발", "#React"],
+        description:
+            "React를 이용해 간단한 캘린더를 제작해주세요. 스토리 보드 및 기획은 이미 완성되어 있는 상태이며, 개발자의 시안 수령 및 구현만이 남아 있습니다. 자세한 api명세와 데이터베이스 관리에 대해서는 논의가 더 필요합니다. ",
+        status: "PROGRESSING",
+    },
+};
+
+export const COMPLETED: Story = {
+    args: {
+        title: "간단한 캘린더 제작",
+        payment: 500000,
+        applicantsCount: 4,
+        estimatedDays: 80,
+        applicationDuration: {
+            startDate: "2023-12-31",
+            endDate: "2024-08-12",
+        },
+        hashtags: ["#개발", "#웹 개발", "#React"],
+        description:
+            "React를 이용해 간단한 캘린더를 제작해주세요. 스토리 보드 및 기획은 이미 완성되어 있는 상태이며, 개발자의 시안 수령 및 구현만이 남아 있습니다. 자세한 api명세와 데이터베이스 관리에 대해서는 논의가 더 필요합니다. ",
+        status: "COMPLETED",
+    },
+};
+
+export const CANCELLED: Story = {
+    args: {
+        title: "간단한 캘린더 제작",
+        payment: 500000,
+        applicantsCount: 4,
+        estimatedDays: 80,
+        applicationDuration: {
+            startDate: "2023-12-31",
+            endDate: "2024-08-12",
+        },
+        hashtags: ["#개발", "#웹 개발", "#React"],
+        description:
+            "React를 이용해 간단한 캘린더를 제작해주세요. 스토리 보드 및 기획은 이미 완성되어 있는 상태이며, 개발자의 시안 수령 및 구현만이 남아 있습니다. 자세한 api명세와 데이터베이스 관리에 대해서는 논의가 더 필요합니다. ",
+        status: "CANCELLED",
     },
 };

--- a/src/components/project/ProjectCard/index.style.ts
+++ b/src/components/project/ProjectCard/index.style.ts
@@ -143,9 +143,9 @@ export const StatusBox = styled.div<{ status: string }>`
     gap: 8px;
     border-radius: 10px;
     background: ${({ status }) =>
-        status === "APPLYING"
+        status === "PREPARING" || status === "APPLYING" || status === "CANCELLED"
             ? "#f4f4f4" // 회색
-            : status === "ACTIVE"
+            : status === "PROGRESSING"
               ? "#F1FAFF" // 파란색
               : "#E2F9E8"};
     box-sizing: border-box;
@@ -153,9 +153,9 @@ export const StatusBox = styled.div<{ status: string }>`
 
 export const StatusText = styled.div<{ status: string }>`
     color: ${({ status }) =>
-        status === "APPLYING"
+        status === "PREPARING" || status === "APPLYING" || status === "CANCELLED"
             ? "#818181" // 회색
-            : status === "ACTIVE"
+            : status === "PROGRESSING"
               ? "#2577C3E5" // 파란색
               : "#69CA7E"};
     text-align: center;
@@ -205,4 +205,5 @@ export const Price = styled.div`
     font-weight: 600;
     line-height: 24px; /* 100% */
     letter-spacing: -0.96px;
+    white-space: nowrap;
 `;

--- a/src/components/project/ProjectCard/index.style.ts
+++ b/src/components/project/ProjectCard/index.style.ts
@@ -142,22 +142,34 @@ export const StatusBox = styled.div<{ status: string }>`
     align-items: center;
     gap: 8px;
     border-radius: 10px;
-    background: ${({ status }) =>
-        status === "PREPARING" || status === "APPLYING" || status === "CANCELLED"
-            ? "#f4f4f4" // 회색
-            : status === "PROGRESSING"
-              ? "#F1FAFF" // 파란색
-              : "#E2F9E8"};
+    background: ${({ status }) => {
+        switch (status) {
+            case "PREPARING":
+            case "APPLYING":
+            case "CANCELLED":
+                return "#f4f4f4";
+            case "PROGRESSING":
+                return "#F1FAFF";
+            case "COMPLETED":
+                return "#E2F9E8";
+        }
+    }};
     box-sizing: border-box;
 `;
 
 export const StatusText = styled.div<{ status: string }>`
-    color: ${({ status }) =>
-        status === "PREPARING" || status === "APPLYING" || status === "CANCELLED"
-            ? "#818181" // 회색
-            : status === "PROGRESSING"
-              ? "#2577C3E5" // 파란색
-              : "#69CA7E"};
+    color: ${({ status }) => {
+        switch (status) {
+            case "PREPARING":
+            case "APPLYING":
+            case "CANCELLED":
+                return "#818181";
+            case "PROGRESSING":
+                return "#2577C3E5";
+            case "COMPLETED":
+                return "#69CA7E";
+        }
+    }};
     text-align: center;
     font-family: Pretendard;
     font-size: 14px;

--- a/src/components/project/ProjectCard/index.tsx
+++ b/src/components/project/ProjectCard/index.tsx
@@ -4,7 +4,7 @@ import { Button } from "principes-getp";
 
 import * as Styles from "./index.style";
 
-export interface ProjectCardProps {
+export interface ProjectCardProps extends React.ComponentProps<"button"> {
     title: string;
     payment: number;
     applicantsCount: number;
@@ -27,6 +27,7 @@ export const ProjectCard = ({
     hashtags,
     description,
     status,
+    onClick,
 }: ProjectCardProps) => {
     const isTabletOrMobile = useMediaQuery({
         query: "(max-width: 1200px)",
@@ -84,7 +85,7 @@ export const ProjectCard = ({
                         <Styles.Price>{payment / 10000}만원</Styles.Price>
                     </Styles.ProjectCarItemLower>
                 </Styles.ItemContainer>
-                <Button variant="outline" width="100%" height="54px">
+                <Button variant="outline" width="100%" height="54px" onClick={onClick}>
                     프로젝트 상세보기
                 </Button>
             </Styles.Container>

--- a/src/components/project/ProjectCard/index.tsx
+++ b/src/components/project/ProjectCard/index.tsx
@@ -35,12 +35,16 @@ export const ProjectCard = ({
     // 상태에 따른 텍스트 변환
     const getStatusText = (status: string) => {
         switch (status) {
+            case "PREPARING":
+                return "준비중";
             case "APPLYING":
                 return "모집중";
-            case "ACTIVE":
+            case "PROGRESSING":
                 return "진행중";
-            case "CLOSE":
+            case "COMPLETED":
                 return "완료";
+            case "CANCELLED":
+                return "취소됨";
             default:
                 return status;
         }

--- a/src/pages/project/ProjectListPage/ProjectListPage.tsx
+++ b/src/pages/project/ProjectListPage/ProjectListPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { Pagination } from "principes-getp";
 
@@ -17,6 +18,7 @@ export interface ISortOption {
 }
 
 export default function ProjectListPage() {
+    const navigate = useNavigate();
     const [sortOrder, setSortOrder] = useState<ISortOption>({ key: "default", title: "기본 정렬" });
     const { isPending, data } = useProjectList();
 
@@ -60,6 +62,7 @@ export default function ProjectListPage() {
                                 hashtags={project.hashtags}
                                 description={project.description}
                                 status={project.status}
+                                onClick={() => navigate(`/projects/${project.projectId}`)}
                             />
                         ))}
                     </>


### PR DESCRIPTION
## ✨ 구현한 기능

- enum에 맞게 프로젝트 상태 표시 스타일 수정
- 프로젝트 카드에서 프로젝트 상세보기를 클릭하면 상세 프로젝트 페이지로 이동하도록 수정
- 프로젝트 카드 스토리북 상태 개수만큼 스토리 추가.

## 📢 논의하고 싶은 내용

- 프로젝트 상태가 총 PREPARING, APPYLING, PROGRESSING, COMPLETED, CANCELED로 5가지가 있는데, PREPARING, APPLYING, CANCELED가 현재 모두 회색으로 표시되는 상황임. 좀 더 구분을 명확하게 하기 위해서 다른 색을 적용할 필요가 있어보임.

## 🎸 기타

-
