### PR TITLE
GETP-317 Fix: 의뢰자 정보 수정시 선택 필드 API 페이로드에서 제외

### DIFF
--- a/get-p-client/src/apps/constants/profileMenuItems.ts
+++ b/get-p-client/src/apps/constants/profileMenuItems.ts
@@ -12,11 +12,11 @@ export const profileMenu = (memberType: MemberType | null): IProfileMenuItem[] =
             {
                 id: 1,
                 text: "의뢰자 정보",
-                to: "/",
+                to: "/client/me/edit",
             },
             {
                 id: 2,
-                text: "관심피플",
+                text: "좋아요한 피플",
                 to: "/people?page=1&size=10&sort=peopleId,desc&liked=true",
             },
             {
@@ -40,12 +40,12 @@ export const profileMenu = (memberType: MemberType | null): IProfileMenuItem[] =
             {
                 id: 1,
                 text: "피플 정보",
-                to: "/",
+                to: "/people/me/info?mode=edit",
             },
             {
                 id: 2,
                 text: "피플 프로필",
-                to: "/",
+                to: "/people/me/profile/edit",
             },
             {
                 id: 3,

--- a/get-p-client/src/apps/router.tsx
+++ b/get-p-client/src/apps/router.tsx
@@ -38,18 +38,19 @@ export const Router = () => {
                 <Route path="people/:id" element={<PeopleDetailPage />}></Route>
 
                 <Route
-                    path="people/me/edit"
-                    element={
-                        <RouteGuard role={MemberType.ROLE_PEOPLE}>
-                            <PeopleProfileEditPage />
-                        </RouteGuard>
-                    }
-                />
-                <Route
-                    path="people/me/register"
+                    path="people/me/info"
                     element={
                         <RouteGuard role={MemberType.ROLE_PEOPLE}>
                             <PeopleInfoRegisterPage />
+                        </RouteGuard>
+                    }
+                />
+
+                <Route
+                    path="people/me/profile/edit"
+                    element={
+                        <RouteGuard role={MemberType.ROLE_PEOPLE}>
+                            <PeopleProfileEditPage />
                         </RouteGuard>
                     }
                 />

--- a/get-p-client/src/apps/router.tsx
+++ b/get-p-client/src/apps/router.tsx
@@ -38,7 +38,7 @@ export const Router = () => {
                 <Route path="people/:id" element={<PeopleDetailPage />}></Route>
 
                 <Route
-                    path="people/edit"
+                    path="people/me/edit"
                     element={
                         <RouteGuard role={MemberType.ROLE_PEOPLE}>
                             <PeopleProfileEditPage />
@@ -46,7 +46,7 @@ export const Router = () => {
                     }
                 />
                 <Route
-                    path="people/register"
+                    path="people/me/register"
                     element={
                         <RouteGuard role={MemberType.ROLE_PEOPLE}>
                             <PeopleInfoRegisterPage />
@@ -55,7 +55,7 @@ export const Router = () => {
                 />
 
                 <Route
-                    path="client/register"
+                    path="client/me/register"
                     element={
                         <RouteGuard role={MemberType.ROLE_CLIENT}>
                             <RegisterClientPage />
@@ -63,7 +63,7 @@ export const Router = () => {
                     }
                 />
                 <Route
-                    path="client/edit"
+                    path="client/me/edit"
                     element={
                         <RouteGuard role={MemberType.ROLE_CLIENT}>
                             <EditClientPage />

--- a/get-p-client/src/common/hooks/useMode.ts
+++ b/get-p-client/src/common/hooks/useMode.ts
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export enum Mode {
+    EDIT = "edit",
+    REGISTER = "register",
+}
+
+export const useMode = (defaultMode: Mode) => {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const mode = searchParams.get("mode");
+
+    useEffect(() => {
+        setSearchParams({ mode: mode || defaultMode });
+    }, [defaultMode, mode, setSearchParams]);
+
+    return {
+        mode: searchParams.get("mode") as Mode,
+    };
+};

--- a/get-p-client/src/components/auth/RegisterInfoModal/index.tsx
+++ b/get-p-client/src/components/auth/RegisterInfoModal/index.tsx
@@ -34,7 +34,7 @@ export const RegisterInfoModal = () => {
 
     const navigateToRegister = useCallback(() => {
         handleClose();
-        navigate(memberType === MemberType.ROLE_CLIENT ? "/client/register" : "/people/register");
+        navigate(memberType === MemberType.ROLE_CLIENT ? "/client/me/register" : "/people/me/register");
     }, [handleClose, memberType, navigate]);
 
     return (

--- a/get-p-client/src/pages/client/EditClientPage/EditClientPage.tsx
+++ b/get-p-client/src/pages/client/EditClientPage/EditClientPage.tsx
@@ -6,6 +6,7 @@ import { Title } from "get-p-design";
 import { ProfileImageEdit } from "@getp/common/components/displays/ProfileImageEdit";
 
 import { useEditClient } from "@getp/services/client/useEditClient";
+import { useMyClient } from "@getp/services/client/useMyClient";
 
 import {
     EditClientPageForm,
@@ -19,6 +20,8 @@ export default function EditClientPage() {
     const { nicknameRef, emailRef, phoneNumberRef, zipCodeRef, streetRef, detailRef, handleRegisterBtnClick } =
         useEditClient();
 
+    const { data } = useMyClient();
+
     return (
         <EditClientPageWrapper>
             <Title>의뢰자 정보 수정</Title>
@@ -30,7 +33,13 @@ export default function EditClientPage() {
 
                 <EditClientPageFormItem>
                     <Label>닉네임(필수)</Label>
-                    <Input ref={nicknameRef} width="100%" height="40px" placeholder="닉네임을 입력해주세요"></Input>
+                    <Input
+                        ref={nicknameRef}
+                        width="100%"
+                        height="40px"
+                        placeholder="닉네임을 입력해주세요"
+                        value={data?.nickname}
+                    />
                 </EditClientPageFormItem>
 
                 <EditClientPageFormItem>
@@ -40,7 +49,8 @@ export default function EditClientPage() {
                         width="100%"
                         height="40px"
                         placeholder="전화번호를 입력해주세요('-' 빼고 숫자만 입력)"
-                    ></Input>
+                        value={data?.phoneNumber}
+                    />
                 </EditClientPageFormItem>
 
                 <EditClientPageFormItem>
@@ -50,18 +60,37 @@ export default function EditClientPage() {
                         width="100%"
                         height="40px"
                         placeholder="의뢰 연락을 받을 다른 이메일이 있는 경우 입력해주세요"
-                    ></Input>
+                        value={data?.email}
+                    />
                 </EditClientPageFormItem>
 
                 <EditClientPageFormItem>
                     <Label>주소(선택)</Label>
-                    <Input width="100%" height="45px" placeholder="우편번호" ref={zipCodeRef}>
+                    <Input
+                        width="100%"
+                        height="45px"
+                        placeholder="우편번호"
+                        ref={zipCodeRef}
+                        value={data?.address.zipcode}
+                    >
                         <Button variant="outline" width="100px" height="40px">
                             우편번호 찾기
                         </Button>
                     </Input>
-                    <Input width="100%" height="45px" placeholder="도로명주소" ref={streetRef}></Input>
-                    <Input width="100%" height="45px" placeholder="상세주소" ref={detailRef}></Input>
+                    <Input
+                        width="100%"
+                        height="45px"
+                        placeholder="도로명주소"
+                        ref={streetRef}
+                        value={data?.address.street}
+                    />
+                    <Input
+                        width="100%"
+                        height="45px"
+                        placeholder="상세주소"
+                        ref={detailRef}
+                        value={data?.address.detail}
+                    />
                 </EditClientPageFormItem>
             </EditClientPageForm>
 

--- a/get-p-client/src/pages/client/EditClientPage/EditClientPage.tsx
+++ b/get-p-client/src/pages/client/EditClientPage/EditClientPage.tsx
@@ -20,7 +20,7 @@ export default function EditClientPage() {
     const { nicknameRef, emailRef, phoneNumberRef, zipCodeRef, streetRef, detailRef, handleRegisterBtnClick } =
         useEditClient();
 
-    const { data } = useMyClient();
+    const { initialMyClientInfo } = useMyClient();
 
     return (
         <EditClientPageWrapper>
@@ -38,7 +38,7 @@ export default function EditClientPage() {
                         width="100%"
                         height="40px"
                         placeholder="닉네임을 입력해주세요"
-                        value={data?.nickname}
+                        defaultValue={initialMyClientInfo?.nickname}
                     />
                 </EditClientPageFormItem>
 
@@ -49,7 +49,7 @@ export default function EditClientPage() {
                         width="100%"
                         height="40px"
                         placeholder="전화번호를 입력해주세요('-' 빼고 숫자만 입력)"
-                        value={data?.phoneNumber}
+                        defaultValue={initialMyClientInfo?.phoneNumber}
                     />
                 </EditClientPageFormItem>
 
@@ -60,7 +60,7 @@ export default function EditClientPage() {
                         width="100%"
                         height="40px"
                         placeholder="의뢰 연락을 받을 다른 이메일이 있는 경우 입력해주세요"
-                        value={data?.email}
+                        defaultValue={initialMyClientInfo?.email}
                     />
                 </EditClientPageFormItem>
 
@@ -71,7 +71,7 @@ export default function EditClientPage() {
                         height="45px"
                         placeholder="우편번호"
                         ref={zipCodeRef}
-                        value={data?.address.zipcode}
+                        defaultValue={initialMyClientInfo?.address.zipcode}
                     >
                         <Button variant="outline" width="100px" height="40px">
                             우편번호 찾기
@@ -82,14 +82,14 @@ export default function EditClientPage() {
                         height="45px"
                         placeholder="도로명주소"
                         ref={streetRef}
-                        value={data?.address.street}
+                        defaultValue={initialMyClientInfo?.address.street}
                     />
                     <Input
                         width="100%"
                         height="45px"
                         placeholder="상세주소"
                         ref={detailRef}
-                        value={data?.address.detail}
+                        defaultValue={initialMyClientInfo?.address.detail}
                     />
                 </EditClientPageFormItem>
             </EditClientPageForm>

--- a/get-p-client/src/pages/people/PeopleInfoRegister/PeopleInfoRegisterPage.tsx
+++ b/get-p-client/src/pages/people/PeopleInfoRegister/PeopleInfoRegisterPage.tsx
@@ -5,7 +5,9 @@ import { Text } from "get-p-design";
 import { Title } from "get-p-design";
 
 import { ProfileImageEdit } from "@getp/common/components/displays/ProfileImageEdit";
+import { Mode, useMode } from "@getp/common/hooks/useMode";
 
+import { useMyPeople } from "@getp/services/people/useMyPeople";
 import { usePeopleInfoRegister } from "@getp/services/people/usePeopleInfoRegister";
 
 import {
@@ -18,11 +20,14 @@ import {
 
 export default function PeopleInfoRegisterPage() {
     const { nicknameRef, emailRef, phoneNumberRef, handleNextClick } = usePeopleInfoRegister();
+    const { initialMyPeopleInfo } = useMyPeople();
+
+    const { mode } = useMode(Mode.REGISTER);
 
     return (
         <PeopleInfoRegisterWrapper>
             <PeopleInfoRegisterHeader>
-                <Title>피플 정보 등록</Title>
+                <Title>피플 정보 {mode === Mode.EDIT ? "수정" : "등록"} </Title>
                 <br />
                 <Text size="16px" weight="bold" color="point">
                     GET-P
@@ -45,7 +50,8 @@ export default function PeopleInfoRegisterPage() {
                         width="100%"
                         height="40px"
                         placeholder="닉네임을 입력해주세요."
-                    ></Input>
+                        defaultValue={initialMyPeopleInfo?.nickname}
+                    />
                 </PeopleInfoRegisterItem>
 
                 <PeopleInfoRegisterItem>
@@ -56,7 +62,8 @@ export default function PeopleInfoRegisterPage() {
                         width="100%"
                         height="40px"
                         placeholder="전화번호를 입력해주세요('-'빼고 숫자만 입력)."
-                    ></Input>
+                        defaultValue={initialMyPeopleInfo?.phoneNumber}
+                    />
                 </PeopleInfoRegisterItem>
 
                 <PeopleInfoRegisterItem>
@@ -67,7 +74,8 @@ export default function PeopleInfoRegisterPage() {
                         width="100%"
                         height="40px"
                         placeholder="의뢰 연락을 받을 다른 이메일이 있는 경우 입력해주세요."
-                    ></Input>
+                        defaultValue={initialMyPeopleInfo?.email}
+                    />
                 </PeopleInfoRegisterItem>
 
                 <PeopleInfoRegisterItem>

--- a/get-p-client/src/services/client/keys.ts
+++ b/get-p-client/src/services/client/keys.ts
@@ -1,4 +1,5 @@
 export const CLIENT_QUERY_KEYS = {
+    READ_MY_CLIENT_INFO: () => ["client_my_info"],
     CLIENT_PROJECT: () => ["client_project"],
     READ_CLIENT_PROJECT_BY_ID: (id: number) => ["client_project", { id }],
     READ_CLIENT_PROJECTS: (page?: number, size?: number, sort?: string) => ["client_projects", { page, size, sort }],

--- a/get-p-client/src/services/client/service.ts
+++ b/get-p-client/src/services/client/service.ts
@@ -9,6 +9,7 @@ import { isRequestBodyValid } from "@getp/common/utils/validation";
 
 import { RenderToastFromDerivedError } from "../exception";
 import {
+    ReadMyClientInfoResponseBody,
     ReadProjectResponseBody,
     RegisterClientRequestBody,
     RegisterClientResponseBody,
@@ -17,6 +18,14 @@ import {
 } from "./types";
 
 export const clientService = {
+    readMyClientInfo: async () => {
+        const request = async () => {
+            const response = await api.get<ReadMyClientInfoResponseBody>("/client/me");
+            return response.data.data;
+        };
+        return request();
+    },
+
     registerClient: async (body: RegisterClientRequestBody) => {
         const request = async () => {
             const response = await api.post<RegisterClientResponseBody>("/client/me", body);

--- a/get-p-client/src/services/client/types.ts
+++ b/get-p-client/src/services/client/types.ts
@@ -2,12 +2,12 @@ import { BaseResponse, PaginatedResponse } from "../types";
 
 export type RegisterClientRequestBody = {
     nickname: string;
-    email: string;
     phoneNumber: string;
-    address: {
-        zipcode: string;
-        street: string;
-        detail: string;
+    email?: string;
+    address?: {
+        zipcode?: string;
+        street?: string;
+        detail?: string;
     };
 };
 export interface ProjectData {
@@ -24,6 +24,21 @@ export interface ProjectData {
     description: string;
     status: string;
 }
+
+export type ReadMyClientInfoResponseBody = BaseResponse<{
+    clientId: number;
+    nickname: string;
+    phoneNumber: string;
+    email: string;
+    profileImageUri: string;
+    address: {
+        zipcode: string;
+        street: string;
+        detail: string;
+    };
+    createdAt: string;
+    updatedAt: string;
+}>;
 
 export type ReadProjectResponseBody = PaginatedResponse<ProjectData[]>;
 

--- a/get-p-client/src/services/client/useMyClient.tsx
+++ b/get-p-client/src/services/client/useMyClient.tsx
@@ -1,0 +1,13 @@
+import { CLIENT_QUERY_KEYS } from "@getp/services/client/keys";
+import { clientService } from "@getp/services/client/service";
+
+import { useQuery } from "@tanstack/react-query";
+
+export const useMyClient = () => {
+    const query = useQuery({
+        queryFn: () => clientService.readMyClientInfo(),
+        queryKey: CLIENT_QUERY_KEYS.READ_MY_CLIENT_INFO(),
+    });
+
+    return { ...query };
+};

--- a/get-p-client/src/services/client/useMyClient.tsx
+++ b/get-p-client/src/services/client/useMyClient.tsx
@@ -1,13 +1,30 @@
-import { CLIENT_QUERY_KEYS } from "@getp/services/client/keys";
+import { useEffect, useState } from "react";
+
 import { clientService } from "@getp/services/client/service";
 
-import { useQuery } from "@tanstack/react-query";
+export type InitialMyClientInfo = {
+    clientId: number;
+    nickname: string;
+    phoneNumber: string;
+    email: string;
+    profileImageUri: string;
+    address: {
+        zipcode: string;
+        street: string;
+        detail: string;
+    };
+    createdAt: string;
+    updatedAt: string;
+};
 
 export const useMyClient = () => {
-    const query = useQuery({
-        queryFn: () => clientService.readMyClientInfo(),
-        queryKey: CLIENT_QUERY_KEYS.READ_MY_CLIENT_INFO(),
-    });
+    const [initialMyClientInfo, setInitialMyClientInfo] = useState<InitialMyClientInfo | null>(null);
 
-    return { ...query };
+    useEffect(function fetchInitialMyClientInfo() {
+        clientService.readMyClientInfo().then((data) => {
+            setInitialMyClientInfo(data);
+        });
+    }, []);
+
+    return { initialMyClientInfo };
 };

--- a/get-p-client/src/services/client/useRegisterClient.tsx
+++ b/get-p-client/src/services/client/useRegisterClient.tsx
@@ -2,6 +2,8 @@ import { useCallback, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
+import { RegisterClientRequestBody } from "@getp/services/client/types";
+
 import { authAction } from "@getp/store/slice/auth.slice";
 import { RootDispatch } from "@getp/store/store";
 
@@ -20,17 +22,22 @@ export const useRegisterClient = () => {
     const detailRef = useRef<HTMLInputElement>(null);
 
     const { mutate } = useMutation({
-        mutationFn: () =>
-            clientService.registerClient({
+        mutationFn: () => {
+            const requestBody: RegisterClientRequestBody = {
                 nickname: nicknameRef.current?.value as string,
-                email: emailRef.current?.value as string,
                 phoneNumber: phoneNumberRef.current?.value as string,
-                address: {
-                    zipcode: zipCodeRef.current?.value as string,
-                    street: streetRef.current?.value as string,
-                    detail: detailRef.current?.value as string,
-                },
-            }),
+            };
+            const address = {
+                zipcode: zipCodeRef.current?.value,
+                street: streetRef.current?.value,
+                detail: detailRef.current?.value,
+            };
+
+            if (emailRef.current?.value) requestBody.email = emailRef.current.value;
+            if (address.zipcode || address.street || address.detail) requestBody.address = address;
+
+            return clientService.registerClient(requestBody);
+        },
         onSuccess: () => {
             dispatch(authAction.registerInfo());
             navigate("/");

--- a/get-p-client/src/services/people/service.ts
+++ b/get-p-client/src/services/people/service.ts
@@ -14,6 +14,8 @@ import {
     RegisterPeopleInfoRequestBody,
     RegisterPeopleProfileRequestBody,
     RegisterPeopleProfileResponseBody,
+    EditPeopleInfoRequestBody,
+    ReadMyPeopleInfoResponseBody,
 } from "./types";
 
 export const peopleService = {
@@ -45,6 +47,13 @@ export const peopleService = {
         const response = await api.get<ReadPeopleResponseBody>(`/people?page=0&size=4&sort=likesCount,desc`);
         return response.data.data;
     },
+    readMyPeopleInfo: async () => {
+        const request = async () => {
+            const response = await api.get<ReadMyPeopleInfoResponseBody>("/people/me");
+            return response.data.data;
+        };
+        return request();
+    },
     registerPeopleInfo: async (body: RegisterPeopleInfoRequestBody) => {
         const request = async () => {
             if (!isRequestBodyValid(body)) throw new Error("모든 정보를 입력해주세요.");
@@ -60,6 +69,21 @@ export const peopleService = {
         return toast.promise(request, {
             pending: "피플 정보 등록 중입니다.",
             success: "피플 정보 등록이 완료되었습니다.",
+            error: RenderToastFromDerivedError,
+        });
+    },
+    editPeopleInfo: async (body: EditPeopleInfoRequestBody) => {
+        const request = async () => {
+            const response = await api.put("/people/me", body);
+
+            return new ExceptionHandler.Builder(response)
+                .addCase(400, "잘못된 입력 형식입니다")
+                .addCase(500, "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+                .activate();
+        };
+        return toast.promise(request, {
+            pending: "피플 정보 수정 중입니다.",
+            success: "피플 정보 수정이 완료되었습니다.",
             error: RenderToastFromDerivedError,
         });
     },

--- a/get-p-client/src/services/people/types.ts
+++ b/get-p-client/src/services/people/types.ts
@@ -50,6 +50,24 @@ export interface RegisterPeopleInfoRequestBody {
     phoneNumber: string;
 }
 
+export type ReadMyPeopleInfoResponseBody = BaseResponse<{
+    peopleId: number;
+    email: string;
+    nickname: string;
+    phoneNumber: string;
+    profileImageUri: string;
+    completedProjectsCount: number;
+    likesCount: number;
+    createdAt: string;
+    updatedAt: string;
+}>;
+
+export interface EditPeopleInfoRequestBody {
+    nickname: string;
+    email: string;
+    phoneNumber: string;
+}
+
 export type RegisterPeopleInfoResponseBody = BaseResponse<{
     peopleId: number;
 }>;

--- a/get-p-client/src/services/people/useMyPeople.tsx
+++ b/get-p-client/src/services/people/useMyPeople.tsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+import { peopleService } from "@getp/services/people/service";
+
+export type MyPeopleInfo = {
+    nickname: string;
+    phoneNumber: string;
+    email: string;
+};
+
+export const useMyPeople = () => {
+    const [initialMyPeopleInfo, setInitialMyPeopleInfo] = useState<MyPeopleInfo | null>(null);
+
+    useEffect(function fetchInitialMyPeopleInfo() {
+        peopleService.readMyPeopleInfo().then((data) => {
+            setInitialMyPeopleInfo(data);
+        });
+    }, []);
+
+    return { initialMyPeopleInfo };
+};

--- a/get-p-client/src/services/people/usePeopleInfoRegister.tsx
+++ b/get-p-client/src/services/people/usePeopleInfoRegister.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { toast } from "react-toastify";
 
 import { queryClient } from "@getp/apps/config/query";
 

--- a/get-p-client/src/services/people/usePeopleInfoRegister.tsx
+++ b/get-p-client/src/services/people/usePeopleInfoRegister.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
+import { toast } from "react-toastify";
 
 import { queryClient } from "@getp/apps/config/query";
+
+import { Mode, useMode } from "@getp/common/hooks/useMode";
 
 import { authAction } from "@getp/store/slice/auth.slice";
 import { RootDispatch } from "@getp/store/store";
@@ -19,14 +22,20 @@ export const usePeopleInfoRegister = () => {
     const phoneNumberRef = useRef<HTMLInputElement | null>(null);
 
     const navigate = useNavigate();
+    const { mode } = useMode(Mode.REGISTER);
 
     const { mutate } = useMutation({
-        mutationFn: () =>
-            peopleService.registerPeopleInfo({
+        mutationFn: () => {
+            const payload = {
                 nickname: nicknameRef.current?.value as string,
                 email: emailRef.current?.value as string,
                 phoneNumber: phoneNumberRef.current?.value as string,
-            }),
+            };
+
+            return mode === Mode.REGISTER
+                ? peopleService.registerPeopleInfo(payload)
+                : peopleService.editPeopleInfo(payload);
+        },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: PEOPLE_QUERY_KEYS.PEOPLE() });
             dispatch(authAction.registerInfo());


### PR DESCRIPTION
## ✨ 구현한 기능

- 의뢰자 정보 수정시 선택 필드 API 페이로드에서 제외
- 의뢰자 정보 수정시 기존 등록된 의뢰자 정보 불러오도록 수정
- 내 피플, 내 의뢰자에 대한 라우터 엔드포인트를 `client/me/~` `people/me/~` 로 수정
- 피플 정보 수정시 defaultValue 추가

## 📢 논의하고 싶은 내용

-

## 🎸 기타

-
