### PR TITLE
GETP-333 Feature: 피플의  지원한 프로젝트 조회 페이지 구현

### DIFF
--- a/get-p-client/src/apps/constants/profileMenuItems.ts
+++ b/get-p-client/src/apps/constants/profileMenuItems.ts
@@ -55,7 +55,7 @@ export const profileMenu = (memberType: MemberType | null): IProfileMenuItem[] =
             {
                 id: 4,
                 text: "프로젝트 관리",
-                to: "/",
+                to: "/people/me/projects",
             },
             {
                 id: 5,

--- a/get-p-client/src/apps/router.tsx
+++ b/get-p-client/src/apps/router.tsx
@@ -16,6 +16,7 @@ import PeopleDetailPage from "@getp/pages/people/PeopleDetail/PeopleDetailPage";
 import PeopleInfoRegisterPage from "@getp/pages/people/PeopleInfoRegister/PeopleInfoRegisterPage";
 import PeopleListPage from "@getp/pages/people/PeopleList/PeopleListPage";
 import PeopleProfileEditPage from "@getp/pages/people/PeopleProfileEdit/PeopleProfileEditPage";
+import PeopleProjectListPage from "@getp/pages/people/PeopleProjectListPage/PeopleProjectListPage";
 import ProjectApplyPage from "@getp/pages/project/ProjectApplyPage/ProjectApplyPage";
 import ProjectDetailPage from "@getp/pages/project/ProjectDetailPage/ProjectDetailPage";
 import ProjectListPage from "@getp/pages/project/ProjectListPage/ProjectListPage";
@@ -38,6 +39,7 @@ export const Router = () => {
                 <Route path="people/:id" element={<PeopleDetailPage />}></Route>
 
                 <Route
+                    // 피플 정보 등록 및 수정
                     path="people/me/info"
                     element={
                         <RouteGuard role={MemberType.ROLE_PEOPLE}>
@@ -47,6 +49,7 @@ export const Router = () => {
                 />
 
                 <Route
+                    // 피플 프로필 등록 및 수정
                     path="people/me/profile/edit"
                     element={
                         <RouteGuard role={MemberType.ROLE_PEOPLE}>
@@ -56,6 +59,16 @@ export const Router = () => {
                 />
 
                 <Route
+                    path="people/me/projects"
+                    element={
+                        <RouteGuard role={MemberType.ROLE_PEOPLE}>
+                            <PeopleProjectListPage />
+                        </RouteGuard>
+                    }
+                />
+
+                <Route
+                    // 의뢰자 정보 등록
                     path="client/me/register"
                     element={
                         <RouteGuard role={MemberType.ROLE_CLIENT}>
@@ -64,6 +77,7 @@ export const Router = () => {
                     }
                 />
                 <Route
+                    // 의뢰자 정보 수정
                     path="client/me/edit"
                     element={
                         <RouteGuard role={MemberType.ROLE_CLIENT}>
@@ -72,6 +86,7 @@ export const Router = () => {
                     }
                 />
                 <Route
+                    // 의뢰자가 의뢰중인 프로젝트
                     path="client/me/projects"
                     element={
                         <RouteGuard role={MemberType.ROLE_CLIENT}>
@@ -79,9 +94,14 @@ export const Router = () => {
                         </RouteGuard>
                     }
                 />
-                <Route path="project/apply/:id" element={<ProjectApplyPage />} />
+                <Route
+                    // 프로젝트 지원하기
+                    path="project/apply/:id"
+                    element={<ProjectApplyPage />}
+                />
 
                 <Route
+                    // 프로젝트 의뢰하기
                     path="project/request"
                     element={
                         <RouteGuard role={MemberType.ROLE_CLIENT}>
@@ -90,7 +110,11 @@ export const Router = () => {
                     }
                 />
 
-                <Route path="projects/:id" element={<ProjectDetailPage />} />
+                <Route
+                    // 프로젝트 상세 페이지
+                    path="projects/:id"
+                    element={<ProjectDetailPage />}
+                />
 
                 <Route
                     path="project/:id/meetings"

--- a/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.style.ts
+++ b/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.style.ts
@@ -1,3 +1,5 @@
+import { mobile, tablet } from "@getp/styles/breakpoint";
+
 import styled from "@emotion/styled";
 
 export const Wrapper = styled.div`
@@ -9,9 +11,24 @@ export const Wrapper = styled.div`
 
 export const Header = styled.div`
     text-align: center;
+    margin: 50px 0px;
 `;
 
 export const Body = styled.div`
     display: grid;
     grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+
+    ${tablet} {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    ${mobile} {
+        grid-template-columns: repeat(1, 1fr);
+    }
+`;
+
+export const Footer = styled.div`
+    display: flex;
+    justify-content: center;
+    margin: 20px 0px;
 `;

--- a/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.style.ts
+++ b/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.style.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+    width: 100%;
+    max-width: 1200px;
+
+    margin: 40px auto;
+`;
+
+export const Header = styled.div`
+    text-align: center;
+`;
+
+export const Body = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+`;

--- a/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.tsx
+++ b/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.tsx
@@ -1,4 +1,4 @@
-import { Text } from "get-p-design";
+import { Pagination, Text } from "get-p-design";
 
 import { ProjectCard } from "@getp/components/project/ProjectCard";
 
@@ -40,6 +40,9 @@ export default function PeopleProjectListPage() {
                         );
                     })}
             </Styles.Body>
+            <Styles.Footer>
+                <Pagination totalPages={data?.pageInfo.totalPages as number} pageGroupSize={6} />
+            </Styles.Footer>
         </Styles.Wrapper>
     );
 }

--- a/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.tsx
+++ b/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.tsx
@@ -1,0 +1,45 @@
+import { Text } from "get-p-design";
+
+import { ProjectCard } from "@getp/components/project/ProjectCard";
+
+import { useAppliedProjects } from "@getp/services/project/useAppliedProjects";
+
+import * as Styles from "./PeopleProjectListPage.style";
+
+export default function PeopleProjectListPage() {
+    const { isPending, data } = useAppliedProjects();
+
+    if (isPending) return <>loading...</>;
+
+    return (
+        <Styles.Wrapper>
+            <Styles.Header>
+                <Text size="xl" weight="bold" style={{ margin: "75px 0px 75px" }}>
+                    피플 {"유지훈"}님의 지원 내역 리스트
+                </Text>
+            </Styles.Header>
+
+            <Styles.Body>
+                {data &&
+                    data.content.map((project) => {
+                        return (
+                            <ProjectCard
+                                key={project.projectId}
+                                title={project.title}
+                                payment={project.payment}
+                                applicantsCount={project.applicantsCount}
+                                estimatedDays={project.estimatedDays}
+                                applicationDuration={{
+                                    startDate: project.applicationDuration.startDate,
+                                    endDate: project.applicationDuration.endDate,
+                                }}
+                                hashtags={project.hashtags}
+                                description={project.description}
+                                status={project.status}
+                            />
+                        );
+                    })}
+            </Styles.Body>
+        </Styles.Wrapper>
+    );
+}

--- a/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.tsx
+++ b/get-p-client/src/pages/people/PeopleProjectListPage/PeopleProjectListPage.tsx
@@ -7,7 +7,7 @@ import { useAppliedProjects } from "@getp/services/project/useAppliedProjects";
 import * as Styles from "./PeopleProjectListPage.style";
 
 export default function PeopleProjectListPage() {
-    const { isPending, data } = useAppliedProjects();
+    const { isPending, data, nickname } = useAppliedProjects();
 
     if (isPending) return <>loading...</>;
 
@@ -15,7 +15,7 @@ export default function PeopleProjectListPage() {
         <Styles.Wrapper>
             <Styles.Header>
                 <Text size="xl" weight="bold" style={{ margin: "75px 0px 75px" }}>
-                    피플 {"유지훈"}님의 지원 내역 리스트
+                    피플 {nickname}님의 지원 내역 리스트
                 </Text>
             </Styles.Header>
 

--- a/get-p-client/src/pages/project/ProjectApplyPage/ProjectApplyPage.tsx
+++ b/get-p-client/src/pages/project/ProjectApplyPage/ProjectApplyPage.tsx
@@ -39,6 +39,7 @@ const ProjectApplyPage = () => {
         peopleType,
         setAttachmentFiles,
     } = useProjectApply();
+
     const { isPending, isError, data: project } = useProjectById();
 
     const { fileInputRef, portfolios, handleFileChange, handleDelete, handleButtonClick } =

--- a/get-p-client/src/services/auth/useAuth.tsx
+++ b/get-p-client/src/services/auth/useAuth.tsx
@@ -1,0 +1,7 @@
+import { useSelector } from "react-redux";
+
+import { RootState } from "@getp/store/store";
+
+export const useAuth = () => {
+    return useSelector((state: RootState) => state.auth);
+};

--- a/get-p-client/src/services/project/keys.ts
+++ b/get-p-client/src/services/project/keys.ts
@@ -6,4 +6,5 @@ export const PROJECT_QUERY_KEYS = {
         { page, size, sort, liked },
     ],
     READ_DEADLINE_PROJECTS: (size?: number) => ["project", "deadline", { size }],
+    READ_APPLIED_PROJECTS: (size?: number) => ["project", "applied", { size }],
 };

--- a/get-p-client/src/services/project/keys.ts
+++ b/get-p-client/src/services/project/keys.ts
@@ -6,5 +6,5 @@ export const PROJECT_QUERY_KEYS = {
         { page, size, sort, liked },
     ],
     READ_DEADLINE_PROJECTS: (size?: number) => ["project", "deadline", { size }],
-    READ_APPLIED_PROJECTS: (size?: number) => ["project", "applied", { size }],
+    READ_APPLIED_PROJECTS: (page?: number, size?: number) => ["project", "applied", { page, size }],
 };

--- a/get-p-client/src/services/project/service.ts
+++ b/get-p-client/src/services/project/service.ts
@@ -126,4 +126,13 @@ export const projectService = {
             error: RenderToastFromDerivedError,
         });
     },
+    readAppliedProjects: async () => {
+        const response = await api.get<ReadProjectResponseBody>("/projects", {
+            params: {
+                applied: true,
+            },
+        });
+
+        return response.data.data;
+    },
 };

--- a/get-p-client/src/services/project/service.ts
+++ b/get-p-client/src/services/project/service.ts
@@ -94,7 +94,7 @@ export const projectService = {
             error: RenderToastFromDerivedError,
         });
     },
-    applyProjectById: async (body: ApplyProjectRequestBody, id = 1) => {
+    applyProjectById: async (body: ApplyProjectRequestBody, id: number) => {
         if (!isRequestBodyValid(body)) throw new Error("모든 정보를 입력해주세요.");
         const request = async () => {
             return await api.post<ApplyProjectRequestBody>(`/projects/${id}/applications`, body);
@@ -126,10 +126,13 @@ export const projectService = {
             error: RenderToastFromDerivedError,
         });
     },
-    readAppliedProjects: async () => {
+    readAppliedProjects: async (page = 0, size = 1, sort = "projectId,desc") => {
         const response = await api.get<ReadProjectResponseBody>("/projects", {
             params: {
                 applied: true,
+                page,
+                size,
+                sort,
             },
         });
 

--- a/get-p-client/src/services/project/types.ts
+++ b/get-p-client/src/services/project/types.ts
@@ -1,3 +1,5 @@
+import { PeopleType } from "@getp/services/people/types";
+
 import { BaseResponse } from "../types";
 import { PaginatedResponse } from "../types";
 
@@ -50,12 +52,14 @@ export interface ProjectData {
 
 export type ReadProjectResponseBody = PaginatedResponse<ProjectData[]>;
 export interface ApplyProjectRequestBody {
+    type: PeopleType;
     expectedDuration: {
         startDate: string;
         endDate: string;
     };
     description: string;
     attachmentFiles: string[];
+    teammates?: number[];
 }
 
 export interface ReadProjectDetailRequestBody {

--- a/get-p-client/src/services/project/useAppliedProjects.tsx
+++ b/get-p-client/src/services/project/useAppliedProjects.tsx
@@ -1,3 +1,5 @@
+import { usePagination } from "get-p-design";
+
 import { useAuth } from "@getp/services/auth/useAuth";
 import { PROJECT_QUERY_KEYS } from "@getp/services/project/keys";
 import { projectService } from "@getp/services/project/service";
@@ -7,9 +9,11 @@ import { useQuery } from "@tanstack/react-query";
 export const useAppliedProjects = () => {
     const { nickname } = useAuth();
 
+    const { currentPage, pageGroupSize } = usePagination();
+
     const query = useQuery({
-        queryFn: () => projectService.readAppliedProjects(),
-        queryKey: PROJECT_QUERY_KEYS.READ_APPLIED_PROJECTS(),
+        queryFn: () => projectService.readAppliedProjects(currentPage - 1, pageGroupSize),
+        queryKey: PROJECT_QUERY_KEYS.READ_APPLIED_PROJECTS(currentPage - 1, pageGroupSize),
     });
     return { ...query, nickname };
 };

--- a/get-p-client/src/services/project/useAppliedProjects.tsx
+++ b/get-p-client/src/services/project/useAppliedProjects.tsx
@@ -1,0 +1,12 @@
+import { PROJECT_QUERY_KEYS } from "@getp/services/project/keys";
+import { projectService } from "@getp/services/project/service";
+
+import { useQuery } from "@tanstack/react-query";
+
+export const useAppliedProjects = () => {
+    const query = useQuery({
+        queryFn: () => projectService.readAppliedProjects(),
+        queryKey: PROJECT_QUERY_KEYS.READ_APPLIED_PROJECTS(),
+    });
+    return { ...query };
+};

--- a/get-p-client/src/services/project/useAppliedProjects.tsx
+++ b/get-p-client/src/services/project/useAppliedProjects.tsx
@@ -1,12 +1,15 @@
+import { useAuth } from "@getp/services/auth/useAuth";
 import { PROJECT_QUERY_KEYS } from "@getp/services/project/keys";
 import { projectService } from "@getp/services/project/service";
 
 import { useQuery } from "@tanstack/react-query";
 
 export const useAppliedProjects = () => {
+    const { nickname } = useAuth();
+
     const query = useQuery({
         queryFn: () => projectService.readAppliedProjects(),
         queryKey: PROJECT_QUERY_KEYS.READ_APPLIED_PROJECTS(),
     });
-    return { ...query };
+    return { ...query, nickname };
 };

--- a/get-p-client/src/services/project/useProjectApply.tsx
+++ b/get-p-client/src/services/project/useProjectApply.tsx
@@ -16,6 +16,7 @@ export const useProjectApply = () => {
     const { mutate } = useMutation({
         mutationFn: () =>
             projectService.applyProjectById({
+                type: peopleType as PeopleType,
                 expectedDuration: {
                     startDate: startDate,
                     endDate: endDate,

--- a/get-p-client/src/services/project/useProjectApply.tsx
+++ b/get-p-client/src/services/project/useProjectApply.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, useRef } from "react";
+import { useParams } from "react-router-dom";
 
 import { PeopleType } from "../people/types";
 import { projectService } from "./service";
@@ -11,19 +12,24 @@ export const useProjectApply = () => {
     const [attachmentFiles, setAttachmentFiles] = useState<{ description: string; url: string }[]>([]);
     const [peopleType, setPeopleType] = useState<PeopleType | null>(null);
 
+    const { id } = useParams();
+
     console.log(attachmentFiles.map((file) => file.url));
 
     const { mutate } = useMutation({
         mutationFn: () =>
-            projectService.applyProjectById({
-                type: peopleType as PeopleType,
-                expectedDuration: {
-                    startDate: startDate,
-                    endDate: endDate,
+            projectService.applyProjectById(
+                {
+                    type: peopleType as PeopleType,
+                    expectedDuration: {
+                        startDate: startDate,
+                        endDate: endDate,
+                    },
+                    description: descriptionRef.current?.value as string,
+                    attachmentFiles: attachmentFiles.map((file) => file.url),
                 },
-                description: descriptionRef.current?.value as string,
-                attachmentFiles: attachmentFiles.map((file) => file.url),
-            }),
+                Number(id),
+            ),
     });
 
     const handleApplyBtnClicked = useCallback(() => {


### PR DESCRIPTION
## ✨ 구현한 기능

- 피플의 지원한 프로젝트 조회 페이지 API 연동 작업을 진행하였습니다
  - 좌측의 프로젝트 성공횟수, 총 수익을 조회할 API 를 찾지 못하여 지원한 프로젝트 조회만 API 연동작업을 진행하였습니다
- 프로젝트 지원시 누락된 `projectId` `page` `size` 파라미터를 추가하였습니다

<img width="500" alt="image" src="https://github.com/user-attachments/assets/93960332-7743-48d0-9192-b3ff920fa502" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b857e6cc-d478-48f9-b749-9f472aa97cf5" />
