### PR TITLE
GETP-335 Feature: 지원한 프로젝트 상세조회 페이지 구현 및 API 연동

### DIFF
--- a/get-p-client/.storybook/preview.tsx
+++ b/get-p-client/.storybook/preview.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 
+import { GlobalStyles } from "../src/apps/styles/styles";
 import { store } from "../src/store/store";
-import { GlobalStyles } from "../src/styles/styles";
 import type { Preview } from "@storybook/react";
 
 const preview: Preview = {

--- a/get-p-client/chromatic.config.json
+++ b/get-p-client/chromatic.config.json
@@ -1,0 +1,6 @@
+{
+  "onlyChanged": true,
+  "projectId": "Project:6634386e77a428543ec2c482",
+  "storybookBaseDir": "get-p-client",
+  "zip": true
+}

--- a/get-p-client/src/apps/router.tsx
+++ b/get-p-client/src/apps/router.tsx
@@ -12,6 +12,7 @@ import MeetingRequestPage from "@getp/pages/client/MeetingRequest/MeetingRequest
 import RegisterClientPage from "@getp/pages/client/RegisterClientPage/RegisterClientPage";
 import NotFoundPage from "@getp/pages/error/NotFoundPage";
 import HomePage from "@getp/pages/home/HomePage";
+import AppliedProjectDetailPage from "@getp/pages/people/AppliedProjectDetail/AppliedProjectDetailPage";
 import PeopleDetailPage from "@getp/pages/people/PeopleDetail/PeopleDetailPage";
 import PeopleInfoRegisterPage from "@getp/pages/people/PeopleInfoRegister/PeopleInfoRegisterPage";
 import PeopleListPage from "@getp/pages/people/PeopleList/PeopleListPage";
@@ -123,6 +124,12 @@ export const Router = () => {
                             <MeetingRequestPage />
                         </RouteGuard>
                     }
+                />
+
+                <Route
+                    // 프로젝트 지원 내역 조회
+                    path="applications/me/:id"
+                    element={<AppliedProjectDetailPage />}
                 />
                 <Route path="*" element={<NotFoundPage />} />
             </Route>

--- a/get-p-client/src/components/project/ProjectOutline/index.tsx
+++ b/get-p-client/src/components/project/ProjectOutline/index.tsx
@@ -34,7 +34,7 @@ export const ProjectOutline = ({
     payment,
     description,
     applicationDuration,
-}: ProjectOutlineProps) => {
+}: Partial<ProjectOutlineProps>) => {
     return (
         <Styles.Wrapper>
             <Styles.HeaderContainer>

--- a/get-p-client/src/components/project/ProjectTeamContainer/index.style.ts
+++ b/get-p-client/src/components/project/ProjectTeamContainer/index.style.ts
@@ -3,8 +3,9 @@ import { ProjectTeamContainerProps } from ".";
 import styled from "@emotion/styled";
 
 export const ProjectTeamContainerWrapper = styled.div<ProjectTeamContainerProps>`
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 4px;
 
     width: ${(props) => props.width};
     height: ${(props) => props.height};

--- a/get-p-client/src/components/project/ProjectTeamItem/index.style.ts
+++ b/get-p-client/src/components/project/ProjectTeamItem/index.style.ts
@@ -10,8 +10,6 @@ export const ItemWrapper = styled.div`
     display: flex;
     align-items: center;
 
-    margin: 5px;
-
     border: 1px solid #ebedef;
     border-radius: 12px;
 

--- a/get-p-client/src/pages/people/AppliedProjectDetail/AppliedProjectDetailPage.style.ts
+++ b/get-p-client/src/pages/people/AppliedProjectDetail/AppliedProjectDetailPage.style.ts
@@ -1,0 +1,93 @@
+import { mobile, tablet } from "@getp/apps/styles/breakpoint";
+
+import styled from "@emotion/styled";
+
+export const Wrapper = styled.div`
+    padding: 20px;
+`;
+
+export const Container = styled.div`
+    display: flex;
+    width: min(100%, 1200px);
+    margin: 0px auto;
+
+    ${tablet} {
+        flex-direction: column;
+    }
+    ${mobile} {
+        flex-direction: column;
+    }
+`;
+
+export const Header = styled.h1`
+    text-align: center;
+    font-size: 24px;
+
+    margin: 30px 0px;
+`;
+
+export const Aside = styled.aside`
+    display: block;
+    margin: 18px;
+    width: 340px;
+    flex-shrink: 0;
+
+    ${tablet} {
+        width: 100%;
+    }
+    ${mobile} {
+        width: 100%;
+    }
+`;
+
+export const Main = styled.article`
+    display: block;
+    width: 100%;
+    margin: 18px;
+`;
+
+export const DateContainer = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+`;
+
+export const DateInfo = styled.div`
+    width: 100%;
+`;
+
+export const Label = styled.label`
+    color: #676f7c;
+`;
+
+export const Contents = styled.div`
+    height: 200px;
+    overflow-y: scroll;
+`;
+
+export const ContentContainer = styled.div`
+    margin: 10px 0px;
+    border-bottom: 1px solid #e0e0e0;
+`;
+
+export const AttachmentFile = styled.div`
+    display: flex;
+    padding: 16px 0px;
+
+    color: black;
+    border-bottom: 1px solid #e0e0e0;
+
+    a {
+        color: black;
+    }
+`;
+
+export const AttachmentFiles = styled.div`
+    margin: 10px 0px;
+`;
+
+export const TeamContainer = styled.div`
+    margin: 10px 0px;
+`;
+
+export const TeamWrapper = styled.div``;

--- a/get-p-client/src/pages/people/AppliedProjectDetail/AppliedProjectDetailPage.tsx
+++ b/get-p-client/src/pages/people/AppliedProjectDetail/AppliedProjectDetailPage.tsx
@@ -1,0 +1,97 @@
+import { FaCircleQuestion } from "react-icons/fa6";
+import { useParams } from "react-router-dom";
+
+import { DatePicker } from "get-p-design";
+
+import { ProjectOutline } from "@getp/components/project/ProjectOutline";
+import { ProjectTeamContainer } from "@getp/components/project/ProjectTeamContainer";
+import { ProjectTeamItem } from "@getp/components/project/ProjectTeamItem";
+
+import { PeopleType } from "@getp/services/people/types";
+import { useAppliedProjectById } from "@getp/services/people/useAppliedProjectById";
+
+import * as Styles from "./AppliedProjectDetailPage.style";
+
+export default function AppliedProjectDetailPage() {
+    const { id } = useParams();
+    const { isPending, data } = useAppliedProjectById(Number(id));
+
+    if (isPending) return <div>Loading...</div>;
+
+    return (
+        <Styles.Wrapper>
+            <Styles.Header>나의 지원 내역</Styles.Header>
+
+            <Styles.Container>
+                <Styles.Aside>
+                    <ProjectOutline
+                        totalDays={0}
+                        remainedDays={0}
+                        title={data?.project.title}
+                        hashtags={data?.project.hashtags}
+                        nickname={data?.project.client.nickname}
+                        clientAddress={data?.project.client.address}
+                        likesCount={data?.project.likesCount}
+                        payment={data?.project.payment}
+                        description={data?.project.description}
+                        applicationDuration={data?.project.applicationDuration}
+                    />
+                </Styles.Aside>
+
+                <Styles.Main>
+                    <Styles.DateContainer>
+                        <Styles.DateInfo>
+                            <Styles.Label>희망 작업 시작일</Styles.Label>
+                            <DatePicker width="100%" height="40px" />
+                        </Styles.DateInfo>
+
+                        <Styles.DateInfo>
+                            <Styles.Label>희망 작업 시작일</Styles.Label>
+                            <DatePicker width="100%" height="40px" />
+                        </Styles.DateInfo>
+
+                        <Styles.DateInfo>
+                            <Styles.Label>희망 작업 시작일</Styles.Label>
+                            <DatePicker width="100%" height="40px" />
+                        </Styles.DateInfo>
+                    </Styles.DateContainer>
+
+                    <Styles.ContentContainer>
+                        <Styles.Label>지원 내용</Styles.Label>
+                        <Styles.Contents>{data?.description}</Styles.Contents>
+                    </Styles.ContentContainer>
+
+                    <Styles.Label>첨부 파일</Styles.Label>
+                    <Styles.AttachmentFiles>
+                        {data?.project.attachmentFiles.map((attachmentFile, index) => {
+                            return (
+                                <Styles.AttachmentFile key={index}>
+                                    <a href={attachmentFile} target="_blank" rel="noreferrer">
+                                        {attachmentFile}
+                                    </a>
+                                </Styles.AttachmentFile>
+                            );
+                        })}
+                    </Styles.AttachmentFiles>
+
+                    {data?.type === PeopleType.TEAM && (
+                        <Styles.TeamWrapper>
+                            <Styles.Label>팀원 정보</Styles.Label>
+                            <ProjectTeamContainer width="100%" height="auto">
+                                {data?.teammates.map((teammate) => (
+                                    <ProjectTeamItem
+                                        id={teammate.peopleId}
+                                        name={teammate.nickname}
+                                        // BUG: email, isAccepted 가 API 응답에 없음
+                                        email={teammate.nickname}
+                                        isAccepted={false}
+                                    />
+                                ))}
+                            </ProjectTeamContainer>
+                        </Styles.TeamWrapper>
+                    )}
+                </Styles.Main>
+            </Styles.Container>
+        </Styles.Wrapper>
+    );
+}

--- a/get-p-client/src/services/people/keys.ts
+++ b/get-p-client/src/services/people/keys.ts
@@ -5,4 +5,5 @@ export const PEOPLE_QUERY_KEYS = {
         { page, size, sort, liked },
     ],
     READ_PEOPLE_BY_ID: (id: number) => ["people", { id }],
+    READ_APPLIED_PROJECT_BY_ID: (id: number) => ["people", "applied-project", { id }],
 };

--- a/get-p-client/src/services/people/service.ts
+++ b/get-p-client/src/services/people/service.ts
@@ -1,11 +1,14 @@
 import { toast } from "react-toastify";
 
 import { AxiosError } from "axios";
+import Exception from "axios-exception-handler";
 
 import { api } from "@getp/apps/config/axios";
 
 import { ExceptionHandler } from "@getp/common/utils/exception";
 import { isRequestBodyValid } from "@getp/common/utils/validation";
+
+import { BaseResponse } from "@getp/services/types";
 
 import { RenderToastFromDerivedError } from "../exception";
 import {
@@ -17,6 +20,7 @@ import {
     RegisterPeopleProfileResponseBody,
     EditPeopleInfoRequestBody,
     ReadMyPeopleInfoResponseBody,
+    ReadAppliedProjectByIdResponseBody,
 } from "./types";
 
 export const peopleService = {
@@ -113,5 +117,12 @@ export const peopleService = {
             success: "피플 프로필 등록 성공!",
             error: RenderToastFromDerivedError,
         });
+    },
+
+    readAppliedProjectById: async (id: number) => {
+        const { data: response } = await api.get<BaseResponse<ReadAppliedProjectByIdResponseBody>>(
+            `/applications/me/${id}`,
+        );
+        return response.data;
     },
 };

--- a/get-p-client/src/services/people/types.ts
+++ b/get-p-client/src/services/people/types.ts
@@ -100,3 +100,53 @@ export type ReadPeopleProfileResponseBody = BaseResponse<{
 }>;
 
 export type RegisterPeopleProfileResponseBody = BaseResponse;
+
+export type ReadAppliedProjectByIdResponseBody = {
+    applicationId: number;
+    type: PeopleType;
+    project: {
+        projectId: number;
+        title: string;
+        payment: number;
+        recruitmentCount: number;
+        applicantsCount: number;
+        applicationDuration: {
+            startDate: string;
+            endDate: string;
+        };
+        estimatedDuration: {
+            startDate: string;
+            endDate: string;
+        };
+        description: string;
+        meetingType: string;
+        category: string;
+        status: string;
+        attachmentFiles: string[];
+        hashtags: string[];
+        likesCount: number;
+        liked: boolean;
+        client: {
+            clientId: number;
+            nickname: string;
+            address: {
+                zipcode: string;
+                street: string;
+                detail: string;
+            };
+        };
+    };
+    expectedDuration: {
+        startDate: string;
+        endDate: string;
+    };
+    status: string;
+    description: string;
+    attachmentFiles: string[];
+    teammates: {
+        peopleId: number;
+        nickname: string;
+        status: string;
+        profileImageUrl: string;
+    }[];
+};

--- a/get-p-client/src/services/people/useAppliedProjectById.tsx
+++ b/get-p-client/src/services/people/useAppliedProjectById.tsx
@@ -1,0 +1,11 @@
+import { PEOPLE_QUERY_KEYS } from "@getp/services/people/keys";
+import { peopleService } from "@getp/services/people/service";
+
+import { useQuery } from "@tanstack/react-query";
+
+export const useAppliedProjectById = (id: number) => {
+    return useQuery({
+        queryKey: PEOPLE_QUERY_KEYS.READ_APPLIED_PROJECT_BY_ID(id),
+        queryFn: () => peopleService.readAppliedProjectById(id),
+    });
+};


### PR DESCRIPTION
## ✨ 구현한 기능

- 지원한 프로젝트 상세조회 페이지를 구현하였습니다
  - 지원한 프로젝트의 타입 (팀 / 개인) 에 따라 팀일 경우, 하단에 팀원 정보를 표시하도록 구현하였습니다

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/a5fbb21e-45f5-4984-9adf-a6966c6d6552" />


## 🎸 기타

- 피플이 지원한 프로젝트 지원 내역 목록페이지에서, 지원한 프로젝트 상세조회페이지로 이동이 불가능합니다
  - 피플이 지원한 프로젝트 지원 내역 조회 응답에는 `applicationId` 가 존재하지 않습니다
